### PR TITLE
Add Hive-backed appointment service with provider state management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,18 @@
 import 'package:flutter/material.dart';
 import 'screens/appointments_page.dart';
+import 'services/appointment_service.dart';
+import 'package:provider/provider.dart';
 
-void main() {
-  runApp(const MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final service = AppointmentService();
+  await service.init();
+  runApp(
+    ChangeNotifierProvider<AppointmentService>.value(
+      value: service,
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -1,0 +1,45 @@
+class Appointment {
+  final String id;
+  final String clientId;
+  final String service;
+  final DateTime dateTime;
+
+  Appointment({
+    required this.id,
+    required this.clientId,
+    required this.service,
+    required this.dateTime,
+  });
+
+  Appointment copyWith({
+    String? id,
+    String? clientId,
+    String? service,
+    DateTime? dateTime,
+  }) {
+    return Appointment(
+      id: id ?? this.id,
+      clientId: clientId ?? this.clientId,
+      service: service ?? this.service,
+      dateTime: dateTime ?? this.dateTime,
+    );
+  }
+
+  factory Appointment.fromMap(Map<dynamic, dynamic> map) {
+    return Appointment(
+      id: map['id'] as String,
+      clientId: map['clientId'] as String,
+      service: map['service'] as String,
+      dateTime: DateTime.parse(map['dateTime'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'clientId': clientId,
+      'service': service,
+      'dateTime': dateTime.toIso8601String(),
+    };
+  }
+}

--- a/lib/models/client.dart
+++ b/lib/models/client.dart
@@ -1,0 +1,27 @@
+class Client {
+  final String id;
+  final String name;
+
+  Client({required this.id, required this.name});
+
+  Client copyWith({String? id, String? name}) {
+    return Client(
+      id: id ?? this.id,
+      name: name ?? this.name,
+    );
+  }
+
+  factory Client.fromMap(Map<dynamic, dynamic> map) {
+    return Client(
+      id: map['id'] as String,
+      name: map['name'] as String,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+    };
+  }
+}

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import '../models/appointment.dart';
+import '../services/appointment_service.dart';
 import 'edit_appointment_page.dart';
 import 'edit_client_page.dart';
 
@@ -8,11 +11,8 @@ class AppointmentsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final appointments = <String>[
-      'Consultation with Alice - Sep 10 10:00 AM',
-      'Facial for Bob - Sep 12 2:00 PM',
-      'Hair styling for Carol - Sep 14 1:00 PM',
-    ];
+    final service = context.watch<AppointmentService>();
+    final appointments = service.appointments;
 
     return Scaffold(
       appBar: AppBar(
@@ -35,17 +35,23 @@ class AppointmentsPage extends StatelessWidget {
       body: ListView.builder(
         itemCount: appointments.length,
         itemBuilder: (context, index) {
-          final appointment = appointments[index];
+          final Appointment appt = appointments[index];
+          final client = service.getClient(appt.clientId);
           return ListTile(
-            title: Text(appointment),
+            title: Text('${client?.name ?? 'Unknown'} - ${appt.service}'),
+            subtitle: Text(appt.dateTime.toLocal().toString()),
             onTap: () {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => EditAppointmentPage(appointment: appointment),
+                  builder: (_) => EditAppointmentPage(appointment: appt),
                 ),
               );
             },
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => service.deleteAppointment(appt.id),
+            ),
           );
         },
       ),

--- a/lib/screens/edit_client_page.dart
+++ b/lib/screens/edit_client_page.dart
@@ -1,16 +1,72 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/client.dart';
+import '../services/appointment_service.dart';
 
 class EditClientPage extends StatelessWidget {
   const EditClientPage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final service = context.watch<AppointmentService>();
+    final clients = service.clients;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Edit Client'),
+        title: const Text('Clients'),
       ),
-      body: const Center(
-        child: Text('Client form goes here'),
+      body: ListView.builder(
+        itemCount: clients.length,
+        itemBuilder: (context, index) {
+          final client = clients[index];
+          return ListTile(
+            title: Text(client.name),
+            onTap: () => _showClientDialog(context, client: client),
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => service.deleteClient(client.id),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showClientDialog(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  void _showClientDialog(BuildContext context, {Client? client}) {
+    final nameController = TextEditingController(text: client?.name ?? '');
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(client == null ? 'New Client' : 'Edit Client'),
+        content: TextField(
+          controller: nameController,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              final service = context.read<AppointmentService>();
+              final id =
+                  client?.id ?? DateTime.now().millisecondsSinceEpoch.toString();
+              final newClient = Client(id: id, name: nameController.text);
+              if (client == null) {
+                service.addClient(newClient);
+              } else {
+                service.updateClient(newClient);
+              }
+              Navigator.pop(context);
+            },
+            child: const Text('Save'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/appointment.dart';
+import '../models/client.dart';
+
+class AppointmentService extends ChangeNotifier {
+  static const _appointmentsBoxName = 'appointments';
+  static const _clientsBoxName = 'clients';
+
+  late Box _appointmentsBox;
+  late Box _clientsBox;
+
+  Future<void> init() async {
+    await Hive.initFlutter();
+    _appointmentsBox = await Hive.openBox(_appointmentsBoxName);
+    _clientsBox = await Hive.openBox(_clientsBoxName);
+  }
+
+  List<Appointment> get appointments => _appointmentsBox.values
+      .map((e) => Appointment.fromMap(Map<String, dynamic>.from(e as Map)))
+      .toList();
+
+  List<Client> get clients => _clientsBox.values
+      .map((e) => Client.fromMap(Map<String, dynamic>.from(e as Map)))
+      .toList();
+
+  Client? getClient(String id) {
+    final map = _clientsBox.get(id);
+    if (map == null) return null;
+    return Client.fromMap(Map<String, dynamic>.from(map as Map));
+  }
+
+  Appointment? getAppointment(String id) {
+    final map = _appointmentsBox.get(id);
+    if (map == null) return null;
+    return Appointment.fromMap(Map<String, dynamic>.from(map as Map));
+  }
+
+  Future<void> addClient(Client client) async {
+    await _clientsBox.put(client.id, client.toMap());
+    notifyListeners();
+  }
+
+  Future<void> updateClient(Client client) async {
+    await _clientsBox.put(client.id, client.toMap());
+    notifyListeners();
+  }
+
+  Future<void> deleteClient(String id) async {
+    await _clientsBox.delete(id);
+    notifyListeners();
+  }
+
+  Future<void> addAppointment(Appointment appointment) async {
+    await _appointmentsBox.put(appointment.id, appointment.toMap());
+    notifyListeners();
+  }
+
+  Future<void> updateAppointment(Appointment appointment) async {
+    await _appointmentsBox.put(appointment.id, appointment.toMap());
+    notifyListeners();
+  }
+
+  Future<void> deleteAppointment(String id) async {
+    await _appointmentsBox.delete(id);
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.0.5
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add client and appointment models
- integrate Hive-powered AppointmentService with CRUD operations
- wire service into UI with Provider

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689975a0ff00832bb81d5505abf43e39