### PR TITLE
Add appointment model and widget tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  mockito: ^5.4.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vogue_vault/models/appointment.dart';
+
+void main() {
+  group('Appointment serialization', () {
+    test('toMap and fromMap produce equivalent objects', () {
+      final appointment = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        service: 'Consultation',
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+      final map = appointment.toMap();
+      final from = Appointment.fromMap(map);
+
+      expect(from.id, appointment.id);
+      expect(from.clientId, appointment.clientId);
+      expect(from.service, appointment.service);
+      expect(from.dateTime, appointment.dateTime);
+    });
+
+    test('fromMap validates required data', () {
+      final missingFields = {'id': 'a1'};
+      expect(() => Appointment.fromMap(missingFields), throwsA(isA<TypeError>()));
+
+      final invalidDate = {
+        'id': 'a1',
+        'clientId': 'c1',
+        'service': 'Consultation',
+        'dateTime': 'invalid',
+      };
+      expect(() => Appointment.fromMap(invalidDate), throwsA(isA<FormatException>()));
+    });
+  });
+}

--- a/test/widget/appointments_page_test.dart
+++ b/test/widget/appointments_page_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/client.dart';
+import 'package:vogue_vault/screens/appointments_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+
+class FakeAppointmentService extends ChangeNotifier implements AppointmentService {
+  final Map<String, Appointment> _appointments = {};
+  final Map<String, Client> _clients = {};
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  List<Appointment> get appointments => _appointments.values.toList();
+
+  @override
+  List<Client> get clients => _clients.values.toList();
+
+  @override
+  Client? getClient(String id) => _clients[id];
+
+  @override
+  Appointment? getAppointment(String id) => _appointments[id];
+
+  @override
+  Future<void> addClient(Client client) async {
+    _clients[client.id] = client;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateClient(Client client) async {
+    _clients[client.id] = client;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> deleteClient(String id) async {
+    _clients.remove(id);
+    notifyListeners();
+  }
+
+  @override
+  Future<void> addAppointment(Appointment appointment) async {
+    _appointments[appointment.id] = appointment;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateAppointment(Appointment appointment) async {
+    _appointments[appointment.id] = appointment;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> deleteAppointment(String id) async {
+    _appointments.remove(id);
+    notifyListeners();
+  }
+}
+
+void main() {
+  testWidgets('Appointments display and actions navigate', (tester) async {
+    final service = FakeAppointmentService();
+    final client = Client(id: 'c1', name: 'Alice');
+    final appointment = Appointment(
+      id: 'a1',
+      clientId: 'c1',
+      service: 'Consultation',
+      dateTime: DateTime(2023, 9, 10, 10),
+    );
+    await service.addClient(client);
+    await service.addAppointment(appointment);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppointmentService>.value(
+        value: service,
+        child: const MaterialApp(home: AppointmentsPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alice - Consultation'), findsOneWidget);
+
+    await tester.tap(find.text('Alice - Consultation'));
+    await tester.pumpAndSettle();
+    expect(find.text('Edit Appointment'), findsOneWidget);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(find.text('New Appointment'), findsOneWidget);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Clients'));
+    await tester.pumpAndSettle();
+    expect(find.text('Clients'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add tests ensuring `Appointment` model serialization and validation
- verify appointments page displays sample data and navigation works
- include `mockito` as a testing helper

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68997951cd5c832ba0cebca7852cf696