### PR TITLE
Use ServiceType enum for appointments

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -1,7 +1,9 @@
+import 'service_type.dart';
+
 class Appointment {
   final String id;
   final String clientId;
-  final String service;
+  final ServiceType service;
   final DateTime dateTime;
 
   Appointment({
@@ -14,7 +16,7 @@ class Appointment {
   Appointment copyWith({
     String? id,
     String? clientId,
-    String? service,
+    ServiceType? service,
     DateTime? dateTime,
   }) {
     return Appointment(
@@ -29,7 +31,7 @@ class Appointment {
     return Appointment(
       id: map['id'] as String,
       clientId: map['clientId'] as String,
-      service: map['service'] as String,
+      service: ServiceType.values.byName(map['service'] as String),
       dateTime: DateTime.parse(map['dateTime'] as String),
     );
   }
@@ -38,7 +40,7 @@ class Appointment {
     return {
       'id': id,
       'clientId': clientId,
-      'service': service,
+      'service': service.name,
       'dateTime': dateTime.toIso8601String(),
     };
   }

--- a/lib/models/service_type.dart
+++ b/lib/models/service_type.dart
@@ -1,0 +1,2 @@
+enum ServiceType { barber, hairdresser, nails }
+

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -38,7 +38,7 @@ class AppointmentsPage extends StatelessWidget {
           final Appointment appt = appointments[index];
           final client = service.getClient(appt.clientId);
           return ListTile(
-            title: Text('${client?.name ?? 'Unknown'} - ${appt.service}'),
+            title: Text('${client?.name ?? 'Unknown'} - ${appt.service.name}'),
             subtitle: Text(appt.dateTime.toLocal().toString()),
             onTap: () {
               Navigator.push(

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/appointment.dart';
+import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 
 class EditAppointmentPage extends StatefulWidget {
@@ -14,23 +15,16 @@ class EditAppointmentPage extends StatefulWidget {
 }
 
 class _EditAppointmentPageState extends State<EditAppointmentPage> {
-  late TextEditingController _serviceController;
+  late ServiceType _service;
   DateTime _dateTime = DateTime.now();
   String? _selectedClientId;
 
   @override
   void initState() {
     super.initState();
-    _serviceController =
-        TextEditingController(text: widget.appointment?.service ?? '');
+    _service = widget.appointment?.service ?? ServiceType.barber;
     _dateTime = widget.appointment?.dateTime ?? DateTime.now();
     _selectedClientId = widget.appointment?.clientId;
-  }
-
-  @override
-  void dispose() {
-    _serviceController.dispose();
-    super.dispose();
   }
 
   @override
@@ -60,9 +54,18 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                   .toList(),
               onChanged: (value) => setState(() => _selectedClientId = value),
             ),
-            TextField(
-              controller: _serviceController,
+            DropdownButtonFormField<ServiceType>(
+              value: _service,
               decoration: const InputDecoration(labelText: 'Service'),
+              items: ServiceType.values
+                  .map(
+                    (s) => DropdownMenuItem<ServiceType>(
+                      value: s,
+                      child: Text(s.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) => setState(() => _service = value!),
             ),
             const SizedBox(height: 12),
             Row(
@@ -102,7 +105,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                       final newAppt = Appointment(
                         id: id,
                         clientId: _selectedClientId!,
-                        service: _serviceController.text,
+                        service: _service,
                         dateTime: _dateTime,
                       );
                       if (isEditing) {

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/service_type.dart';
 
 void main() {
   group('Appointment serialization', () {
@@ -7,7 +8,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
-        service: 'Consultation',
+        service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
       final map = appointment.toMap();
@@ -26,7 +27,7 @@ void main() {
       final invalidDate = {
         'id': 'a1',
         'clientId': 'c1',
-        'service': 'Consultation',
+        'service': 'barber',
         'dateTime': 'invalid',
       };
       expect(() => Appointment.fromMap(invalidDate), throwsA(isA<FormatException>()));

--- a/test/widget/appointments_page_test.dart
+++ b/test/widget/appointments_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:vogue_vault/models/appointment.dart';
 import 'package:vogue_vault/models/client.dart';
+import 'package:vogue_vault/models/service_type.dart';
 import 'package:vogue_vault/screens/appointments_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 
@@ -69,7 +70,7 @@ void main() {
     final appointment = Appointment(
       id: 'a1',
       clientId: 'c1',
-      service: 'Consultation',
+      service: ServiceType.barber,
       dateTime: DateTime(2023, 9, 10, 10),
     );
     await service.addClient(client);
@@ -83,9 +84,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Alice - Consultation'), findsOneWidget);
+    expect(find.text('Alice - barber'), findsOneWidget);
 
-    await tester.tap(find.text('Alice - Consultation'));
+    await tester.tap(find.text('Alice - barber'));
     await tester.pumpAndSettle();
     expect(find.text('Edit Appointment'), findsOneWidget);
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,6 +5,6 @@ void main() {
   testWidgets('Appointments page shows sample data', (tester) async {
     await tester.pumpWidget(const MyApp());
 
-    expect(find.text('Consultation with Alice - Sep 10 10:00 AM'), findsOneWidget);
+    expect(find.text('barber with Alice - Sep 10 10:00 AM'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Introduce `ServiceType` enum to model barber, hairdresser, and nails services
- Store service selection in `Appointment` as the enum and persist enum name with Hive
- Update appointment editing and listing screens and tests for enum-based services

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68997dc4c954832b8dcda143fbaa2ff2