### PR TITLE
feat: add service type icons and labels

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -29,6 +29,17 @@ IconData serviceTypeIcon(ServiceType type) {
   }
 }
 
+Color serviceTypeColor(ServiceType type) {
+  switch (type) {
+    case ServiceType.barber:
+      return Colors.blue;
+    case ServiceType.hairdresser:
+      return Colors.purple;
+    case ServiceType.nails:
+      return Colors.pink;
+  }
+}
+
 class AppointmentsPage extends StatelessWidget {
   const AppointmentsPage({super.key});
 
@@ -61,7 +72,13 @@ class AppointmentsPage extends StatelessWidget {
           final Appointment appt = appointments[index];
           final client = service.getClient(appt.clientId);
           return ListTile(
-            leading: Icon(serviceTypeIcon(appt.service)),
+            leading: CircleAvatar(
+              backgroundColor: serviceTypeColor(appt.service),
+              child: Icon(
+                serviceTypeIcon(appt.service),
+                color: Colors.white,
+              ),
+            ),
             title: Text(
               '${client?.name ?? 'Unknown'} - ${serviceTypeLabel(appt.service)}',
             ),

--- a/test/widget/appointments_page_test.dart
+++ b/test/widget/appointments_page_test.dart
@@ -84,9 +84,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Alice - barber'), findsOneWidget);
+    expect(find.text('Alice - Barber'), findsOneWidget);
 
-    await tester.tap(find.text('Alice - barber'));
+    await tester.tap(find.text('Alice - Barber'));
     await tester.pumpAndSettle();
     expect(find.text('Edit Appointment'), findsOneWidget);
 


### PR DESCRIPTION
## Summary
- map service types to human-readable labels, icons, and colors
- display service icons with colored avatars in appointments list
- update widget test to match new labels

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6899d63b55fc832bb87c800136af1df0