### PR TITLE
Add welcome screen with service categories

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'screens/appointments_page.dart';
+import 'screens/welcome_page.dart';
 import 'services/appointment_service.dart';
 import 'package:provider/provider.dart';
 
@@ -25,7 +26,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const AppointmentsPage(),
+      home: const WelcomePage(),
     );
   }
 }

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -3,42 +3,10 @@ import 'package:provider/provider.dart';
 
 import '../models/appointment.dart';
 import '../models/service_type.dart';
+import '../utils/service_type_utils.dart';
 import '../services/appointment_service.dart';
 import 'edit_appointment_page.dart';
 import 'edit_client_page.dart';
-
-String serviceTypeLabel(ServiceType type) {
-  switch (type) {
-    case ServiceType.barber:
-      return 'Barber';
-    case ServiceType.hairdresser:
-      return 'Hairdresser';
-    case ServiceType.nails:
-      return 'Nails';
-  }
-}
-
-IconData serviceTypeIcon(ServiceType type) {
-  switch (type) {
-    case ServiceType.barber:
-      return Icons.content_cut;
-    case ServiceType.hairdresser:
-      return Icons.brush;
-    case ServiceType.nails:
-      return Icons.spa;
-  }
-}
-
-Color serviceTypeColor(ServiceType type) {
-  switch (type) {
-    case ServiceType.barber:
-      return Colors.blue;
-    case ServiceType.hairdresser:
-      return Colors.purple;
-    case ServiceType.nails:
-      return Colors.pink;
-  }
-}
 
 class AppointmentsPage extends StatelessWidget {
   const AppointmentsPage({super.key});

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../models/service_type.dart';
+import '../utils/service_type_utils.dart';
+import 'appointments_page.dart';
+
+class WelcomePage extends StatelessWidget {
+  const WelcomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Welcome'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Explore our services',
+              style: Theme.of(context).textTheme.headline6,
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: GridView.count(
+                crossAxisCount: 2,
+                crossAxisSpacing: 16,
+                mainAxisSpacing: 16,
+                children: ServiceType.values
+                    .map((type) => _ServiceCard(type: type))
+                    .toList(),
+              ),
+            ),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const AppointmentsPage(),
+                    ),
+                  );
+                },
+                child: const Text('Get Started'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ServiceCard extends StatelessWidget {
+  final ServiceType type;
+
+  const _ServiceCard({required this.type});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: InkWell(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => const AppointmentsPage(),
+            ),
+          );
+        },
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                serviceTypeIcon(type),
+                size: 40,
+                color: serviceTypeColor(type),
+              ),
+              const SizedBox(height: 8),
+              Text(serviceTypeLabel(type)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../models/service_type.dart';
+
+String serviceTypeLabel(ServiceType type) {
+  switch (type) {
+    case ServiceType.barber:
+      return 'Barbershop';
+    case ServiceType.hairdresser:
+      return 'Hairdresser';
+    case ServiceType.nails:
+      return 'Nails';
+  }
+}
+
+IconData serviceTypeIcon(ServiceType type) {
+  switch (type) {
+    case ServiceType.barber:
+      return Icons.content_cut;
+    case ServiceType.hairdresser:
+      return Icons.brush;
+    case ServiceType.nails:
+      return Icons.spa;
+  }
+}
+
+Color serviceTypeColor(ServiceType type) {
+  switch (type) {
+    case ServiceType.barber:
+      return Colors.blue;
+    case ServiceType.hairdresser:
+      return Colors.purple;
+    case ServiceType.nails:
+      return Colors.pink;
+  }
+}


### PR DESCRIPTION
## Summary
- create reusable service type utilities for labels, icons, and colors
- add welcome page highlighting barbershop, hairdresser, and nails services
- start app with new onboarding screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899daafeeac832ba1f1e0a171bf92e7