### PR TITLE
Dispose Hive boxes and update provider creation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,8 +9,8 @@ void main() async {
   final service = AppointmentService();
   await service.init();
   runApp(
-    ChangeNotifierProvider<AppointmentService>.value(
-      value: service,
+    ChangeNotifierProvider<AppointmentService>(
+      create: (_) => service,
       child: const MyApp(),
     ),
   );

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -66,4 +66,11 @@ class AppointmentService extends ChangeNotifier {
     await _appointmentsBox.delete(id);
     notifyListeners();
   }
+
+  @override
+  void dispose() {
+    _appointmentsBox.close();
+    _clientsBox.close();
+    super.dispose();
+  }
 }


### PR DESCRIPTION
## Summary
- ensure AppointmentService closes Hive boxes via dispose override
- switch ChangeNotifierProvider to `create` constructor to allow automatic dispose

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fd37aed0832ba57d17727668f4dc