### PR TITLE
Use typed Hive boxes to avoid runtime casts

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -27,7 +27,7 @@ class Appointment {
     );
   }
 
-  factory Appointment.fromMap(Map<dynamic, dynamic> map) {
+  factory Appointment.fromMap(Map<String, dynamic> map) {
     return Appointment(
       id: map['id'] as String,
       clientId: map['clientId'] as String,

--- a/lib/models/client.dart
+++ b/lib/models/client.dart
@@ -11,7 +11,7 @@ class Client {
     );
   }
 
-  factory Client.fromMap(Map<dynamic, dynamic> map) {
+  factory Client.fromMap(Map<String, dynamic> map) {
     return Client(
       id: map['id'] as String,
       name: map['name'] as String,

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -8,33 +8,33 @@ class AppointmentService extends ChangeNotifier {
   static const _appointmentsBoxName = 'appointments';
   static const _clientsBoxName = 'clients';
 
-  late Box _appointmentsBox;
-  late Box _clientsBox;
+  late Box<Map<String, dynamic>> _appointmentsBox;
+  late Box<Map<String, dynamic>> _clientsBox;
 
   Future<void> init() async {
     await Hive.initFlutter();
-    _appointmentsBox = await Hive.openBox(_appointmentsBoxName);
-    _clientsBox = await Hive.openBox(_clientsBoxName);
+    _appointmentsBox =
+        await Hive.openBox<Map<String, dynamic>>(_appointmentsBoxName);
+    _clientsBox =
+        await Hive.openBox<Map<String, dynamic>>(_clientsBoxName);
   }
 
-  List<Appointment> get appointments => _appointmentsBox.values
-      .map((e) => Appointment.fromMap(Map<String, dynamic>.from(e as Map)))
-      .toList();
+  List<Appointment> get appointments =>
+      _appointmentsBox.values.map(Appointment.fromMap).toList();
 
-  List<Client> get clients => _clientsBox.values
-      .map((e) => Client.fromMap(Map<String, dynamic>.from(e as Map)))
-      .toList();
+  List<Client> get clients =>
+      _clientsBox.values.map(Client.fromMap).toList();
 
   Client? getClient(String id) {
     final map = _clientsBox.get(id);
     if (map == null) return null;
-    return Client.fromMap(Map<String, dynamic>.from(map as Map));
+    return Client.fromMap(map);
   }
 
   Appointment? getAppointment(String id) {
     final map = _appointmentsBox.get(id);
     if (map == null) return null;
-    return Appointment.fromMap(Map<String, dynamic>.from(map as Map));
+    return Appointment.fromMap(map);
   }
 
   Future<void> addClient(Client client) async {


### PR DESCRIPTION
## Summary
- use typed `Box<Map<String, dynamic>>` for appointments and clients
- simplify mapping from Hive results
- adjust models to accept `Map<String, dynamic>`

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0556f338832b9415584e427feed8