### PR TITLE
test: use fake appointment service for widget tests

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,79 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:vogue_vault/main.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/client.dart';
+import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/screens/appointments_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+
+class FakeAppointmentService extends AppointmentService {
+  FakeAppointmentService({
+    required List<Appointment> appointments,
+    required List<Client> clients,
+  })  : _appointments = appointments,
+        _clients = {for (final c in clients) c.id: c};
+
+  final List<Appointment> _appointments;
+  final Map<String, Client> _clients;
+
+  @override
+  List<Appointment> get appointments => _appointments;
+
+  @override
+  List<Client> get clients => _clients.values.toList();
+
+  @override
+  Client? getClient(String id) => _clients[id];
+
+  @override
+  Appointment? getAppointment(String id) {
+    try {
+      return _appointments.firstWhere((a) => a.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> deleteAppointment(String id) async {
+    _appointments.removeWhere((a) => a.id == id);
+    notifyListeners();
+  }
+}
 
 void main() {
-  testWidgets('Appointments page shows sample data', (tester) async {
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Appointments page shows appointment titles and navigates',
+      (tester) async {
+    final client = Client(id: 'c1', name: 'Alice');
+    final appointment = Appointment(
+      id: 'a1',
+      clientId: client.id,
+      service: ServiceType.barber,
+      dateTime: DateTime(2023, 9, 10, 10, 0),
+    );
+    final service = FakeAppointmentService(
+      appointments: [appointment],
+      clients: [client],
+    );
 
-    expect(find.text('barber with Alice - Sep 10 10:00 AM'), findsOneWidget);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppointmentService>.value(
+        value: service,
+        child: const MaterialApp(
+          home: AppointmentsPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alice - Barbershop'), findsOneWidget);
+
+    await tester.tap(find.text('Alice - Barbershop'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit Appointment'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- provide FakeAppointmentService with sample data via ChangeNotifierProvider
- verify appointment title and navigation behavior in widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a08c5a804832bbb2ba48752e2e1d6