### PR TITLE
chore: enable additional lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,8 +21,10 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    prefer_const_constructors: true
+    prefer_single_quotes: true
+    unawaited_futures: true
+    # avoid_print: false  # Example of disabling the `avoid_print` rule
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Summary
- add prefer_const_constructors, prefer_single_quotes, and unawaited_futures lint rules

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0fd29038832b8b302fc75800965a