### PR TITLE
Add docs and value equality for models

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -1,11 +1,20 @@
 import 'service_type.dart';
 
+/// Represents a scheduled appointment for a client.
 class Appointment {
+  /// Unique identifier for the appointment.
   final String id;
+
+  /// Identifier of the client booking the appointment.
   final String clientId;
+
+  /// The type of service being scheduled.
   final ServiceType service;
+
+  /// The date and time when the appointment takes place.
   final DateTime dateTime;
 
+  /// Creates a new [Appointment].
   Appointment({
     required this.id,
     required this.clientId,
@@ -13,6 +22,7 @@ class Appointment {
     required this.dateTime,
   });
 
+  /// Returns a copy of this appointment with the given fields replaced.
   Appointment copyWith({
     String? id,
     String? clientId,
@@ -27,6 +37,7 @@ class Appointment {
     );
   }
 
+  /// Creates an [Appointment] from a JSON-compatible [map].
   factory Appointment.fromMap(Map<String, dynamic> map) {
     return Appointment(
       id: map['id'] as String,
@@ -36,6 +47,7 @@ class Appointment {
     );
   }
 
+  /// Converts this appointment into a JSON-compatible map.
   Map<String, dynamic> toMap() {
     return {
       'id': id,
@@ -44,4 +56,18 @@ class Appointment {
       'dateTime': dateTime.toIso8601String(),
     };
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Appointment &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          clientId == other.clientId &&
+          service == other.service &&
+          dateTime == other.dateTime;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^ clientId.hashCode ^ service.hashCode ^ dateTime.hashCode;
 }

--- a/lib/models/client.dart
+++ b/lib/models/client.dart
@@ -1,9 +1,15 @@
+/// Represents a client that can book services.
 class Client {
+  /// Unique identifier for the client.
   final String id;
+
+  /// Display name of the client.
   final String name;
 
+  /// Creates a new [Client] instance.
   Client({required this.id, required this.name});
 
+  /// Returns a copy of this client with the provided values replaced.
   Client copyWith({String? id, String? name}) {
     return Client(
       id: id ?? this.id,
@@ -11,6 +17,7 @@ class Client {
     );
   }
 
+  /// Creates a [Client] from a JSON-compatible [map].
   factory Client.fromMap(Map<String, dynamic> map) {
     return Client(
       id: map['id'] as String,
@@ -18,10 +25,22 @@ class Client {
     );
   }
 
+  /// Converts this client to a JSON-compatible map.
   Map<String, dynamic> toMap() {
     return {
       'id': id,
       'name': name,
     };
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Client &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name;
+
+  @override
+  int get hashCode => id.hashCode ^ name.hashCode;
 }

--- a/lib/models/service_type.dart
+++ b/lib/models/service_type.dart
@@ -1,2 +1,12 @@
-enum ServiceType { barber, hairdresser, nails }
+/// The different types of services that can be booked.
+enum ServiceType {
+  /// Traditional barber services.
+  barber,
+
+  /// General hairdressing and styling services.
+  hairdresser,
+
+  /// Manicure or pedicure services.
+  nails,
+}
 

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -33,4 +33,41 @@ void main() {
       expect(() => Appointment.fromMap(invalidDate), throwsA(isA<FormatException>()));
     });
   });
+
+  group('Appointment equality', () {
+    test('appointments with the same values are equal', () {
+      final a1 = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+      final a2 = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+
+      expect(a1, equals(a2));
+      expect(a1.hashCode, equals(a2.hashCode));
+    });
+
+    test('appointments with different values are not equal', () {
+      final a1 = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+      final a2 = Appointment(
+        id: 'a2',
+        clientId: 'c1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+
+      expect(a1, isNot(equals(a2)));
+    });
+  });
 }

--- a/test/models/client_test.dart
+++ b/test/models/client_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vogue_vault/models/client.dart';
+
+void main() {
+  group('Client equality', () {
+    test('clients with same values are equal', () {
+      final c1 = Client(id: 'c1', name: 'Alice');
+      final c2 = Client(id: 'c1', name: 'Alice');
+
+      expect(c1, equals(c2));
+      expect(c1.hashCode, equals(c2.hashCode));
+    });
+
+    test('clients with different values are not equal', () {
+      final c1 = Client(id: 'c1', name: 'Alice');
+      final c2 = Client(id: 'c2', name: 'Alice');
+
+      expect(c1, isNot(equals(c2)));
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- document models with Dartdoc and enable value equality
- add tests covering equality for Appointment and Client

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a10ec2124832b92173199af2eb9af