### PR TITLE
Add validation to client and appointment forms

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -15,6 +15,7 @@ class EditAppointmentPage extends StatefulWidget {
 }
 
 class _EditAppointmentPageState extends State<EditAppointmentPage> {
+  final _formKey = GlobalKey<FormState>();
   late ServiceType _service;
   DateTime _dateTime = DateTime.now();
   String? _selectedClientId;
@@ -39,85 +40,91 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            DropdownButtonFormField<String>(
-              value: _selectedClientId,
-              hint: const Text('Select Client'),
-              items: clients
-                  .map(
-                    (c) => DropdownMenuItem<String>(
-                      value: c.id,
-                      child: Text(c.name),
-                    ),
-                  )
-                  .toList(),
-              onChanged: (value) => setState(() => _selectedClientId = value),
-            ),
-            DropdownButtonFormField<ServiceType>(
-              value: _service,
-              decoration: const InputDecoration(labelText: 'Service'),
-              items: ServiceType.values
-                  .map(
-                    (s) => DropdownMenuItem<ServiceType>(
-                      value: s,
-                      child: Text(s.name),
-                    ),
-                  )
-                  .toList(),
-              onChanged: (value) => setState(() => _service = value!),
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Text(_dateTime.toLocal().toString()),
-                const SizedBox(width: 8),
-                TextButton(
-                  onPressed: () async {
-                    final date = await showDatePicker(
-                      context: context,
-                      initialDate: _dateTime,
-                      firstDate: DateTime(2000),
-                      lastDate: DateTime(2100),
-                    );
-                    if (date == null) return;
-                    final time = await showTimePicker(
-                      context: context,
-                      initialTime: TimeOfDay.fromDateTime(_dateTime),
-                    );
-                    if (time == null) return;
-                    setState(() {
-                      _dateTime = DateTime(
-                          date.year, date.month, date.day, time.hour, time.minute);
-                    });
-                  },
-                  child: const Text('Select Date'),
-                ),
-              ],
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: _selectedClientId == null
-                  ? null
-                  : () {
-                      final id = widget.appointment?.id ??
-                          DateTime.now().millisecondsSinceEpoch.toString();
-                      final newAppt = Appointment(
-                        id: id,
-                        clientId: _selectedClientId!,
-                        service: _service,
-                        dateTime: _dateTime,
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              DropdownButtonFormField<String>(
+                value: _selectedClientId,
+                hint: const Text('Select Client'),
+                items: clients
+                    .map(
+                      (c) => DropdownMenuItem<String>(
+                        value: c.id,
+                        child: Text(c.name),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) => setState(() => _selectedClientId = value),
+                validator: (value) =>
+                    value == null ? 'Please select a client' : null,
+              ),
+              DropdownButtonFormField<ServiceType>(
+                value: _service,
+                decoration: const InputDecoration(labelText: 'Service'),
+                items: ServiceType.values
+                    .map(
+                      (s) => DropdownMenuItem<ServiceType>(
+                        value: s,
+                        child: Text(s.name),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) => setState(() => _service = value!),
+                validator: (value) =>
+                    value == null ? 'Please select a service' : null,
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Text(_dateTime.toLocal().toString()),
+                  const SizedBox(width: 8),
+                  TextButton(
+                    onPressed: () async {
+                      final date = await showDatePicker(
+                        context: context,
+                        initialDate: _dateTime,
+                        firstDate: DateTime(2000),
+                        lastDate: DateTime(2100),
                       );
-                      if (isEditing) {
-                        service.updateAppointment(newAppt);
-                      } else {
-                        service.addAppointment(newAppt);
-                      }
-                      Navigator.pop(context);
+                      if (date == null) return;
+                      final time = await showTimePicker(
+                        context: context,
+                        initialTime: TimeOfDay.fromDateTime(_dateTime),
+                      );
+                      if (time == null) return;
+                      setState(() {
+                        _dateTime = DateTime(
+                            date.year, date.month, date.day, time.hour, time.minute);
+                      });
                     },
-              child: const Text('Save'),
-            ),
-          ],
+                    child: const Text('Select Date'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () {
+                  if (!_formKey.currentState!.validate()) return;
+                  final id = widget.appointment?.id ??
+                      DateTime.now().millisecondsSinceEpoch.toString();
+                  final newAppt = Appointment(
+                    id: id,
+                    clientId: _selectedClientId!,
+                    service: _service,
+                    dateTime: _dateTime,
+                  );
+                  if (isEditing) {
+                    service.updateAppointment(newAppt);
+                  } else {
+                    service.addAppointment(newAppt);
+                  }
+                  Navigator.pop(context);
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/edit_client_page.dart
+++ b/lib/screens/edit_client_page.dart
@@ -38,13 +38,19 @@ class EditClientPage extends StatelessWidget {
 
   Future<void> _showClientDialog(BuildContext context, {Client? client}) async {
     final nameController = TextEditingController(text: client?.name ?? '');
+    final formKey = GlobalKey<FormState>();
     await showDialog(
       context: context,
       builder: (_) => AlertDialog(
         title: Text(client == null ? 'New Client' : 'Edit Client'),
-        content: TextField(
-          controller: nameController,
-          decoration: const InputDecoration(labelText: 'Name'),
+        content: Form(
+          key: formKey,
+          child: TextFormField(
+            controller: nameController,
+            decoration: const InputDecoration(labelText: 'Name'),
+            validator: (value) =>
+                value == null || value.trim().isEmpty ? 'Please enter a name' : null,
+          ),
         ),
         actions: [
           TextButton(
@@ -53,6 +59,7 @@ class EditClientPage extends StatelessWidget {
           ),
           TextButton(
             onPressed: () async {
+              if (!formKey.currentState!.validate()) return;
               final service = context.read<AppointmentService>();
               final id =
                   client?.id ?? DateTime.now().millisecondsSinceEpoch.toString();


### PR DESCRIPTION
## Summary
- Wrap client name and appointment inputs in Form widgets keyed with GlobalKey<FormState>
- Add TextFormField and Dropdown validators for required name and client/service selections
- Validate forms before saving to surface errors

## Testing
- `flutter --version` (fails: command not found)
- `flutter test` (fails: command not found)
- `dart test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689a16e6e9d4832bbb0fec1f3c387c49