### PR TITLE
Initialize AppointmentService inside provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'screens/appointments_page.dart';
-import 'screens/welcome_page.dart';
-import 'services/appointment_service.dart';
 import 'package:provider/provider.dart';
 
-void main() async {
+import 'screens/welcome_page.dart';
+import 'services/appointment_service.dart';
+
+void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  final service = AppointmentService();
-  await service.init();
   runApp(
     ChangeNotifierProvider<AppointmentService>(
-      create: (_) => service,
+      create: (_) {
+        final service = AppointmentService();
+        unawaited(service.init());
+        return service;
+      },
       child: const MyApp(),
     ),
   );


### PR DESCRIPTION
## Summary
- initialize `AppointmentService` within `ChangeNotifierProvider`'s `create` callback
- avoid pre-instantiation and allow provider to manage service lifecycle

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a18ef8754832b8cf1be430c433dac