### PR TITLE
Add role provider and user role enum

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,16 +5,24 @@ import 'package:provider/provider.dart';
 
 import 'screens/welcome_page.dart';
 import 'services/appointment_service.dart';
+import 'services/role_provider.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   runApp(
-    ChangeNotifierProvider<AppointmentService>(
-      create: (_) {
-        final service = AppointmentService();
-        unawaited(service.init());
-        return service;
-      },
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<AppointmentService>(
+          create: (_) {
+            final service = AppointmentService();
+            unawaited(service.init());
+            return service;
+          },
+        ),
+        ChangeNotifierProvider<RoleProvider>(
+          create: (_) => RoleProvider(),
+        ),
+      ],
       child: const MyApp(),
     ),
   );

--- a/lib/models/user_role.dart
+++ b/lib/models/user_role.dart
@@ -1,0 +1,8 @@
+/// The different user roles within the app.
+enum UserRole {
+  /// A customer booking services.
+  customer,
+
+  /// A professional offering services.
+  professional,
+}

--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/user_role.dart';
+
+class RoleProvider extends ChangeNotifier {
+  UserRole? _selectedRole;
+
+  UserRole? get selectedRole => _selectedRole;
+
+  set selectedRole(UserRole? role) {
+    _selectedRole = role;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `UserRole` enum for customer vs professional users
- add `RoleProvider` ChangeNotifier to manage selected user role
- register `RoleProvider` alongside `AppointmentService` in the app root

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a41d2c9fc832bb55b6489ea58d0bc