### PR TITLE
Add role selection page for customer and professional roles

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'screens/welcome_page.dart';
+import 'screens/role_selection_page.dart';
 import 'services/appointment_service.dart';
 import 'services/role_provider.dart';
 
@@ -38,7 +38,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const WelcomePage(),
+      home: const RoleSelectionPage(),
     );
   }
 }

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/user_role.dart';
+import '../services/role_provider.dart';
+import 'appointments_page.dart';
+import 'welcome_page.dart';
+
+class RoleSelectionPage extends StatelessWidget {
+  const RoleSelectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select Role'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'I am a...',
+                style: theme.textTheme.titleLarge,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    context.read<RoleProvider>().selectedRole = UserRole.customer;
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const WelcomePage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Customer'),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    context.read<RoleProvider>().selectedRole = UserRole.professional;
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const AppointmentsPage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Professional'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add new RoleSelectionPage offering Customer and Professional choices
- update main.dart to launch RoleSelectionPage

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689a496bc38c832b9a5a942a126bde19