### PR TITLE
Guard editing features for professionals

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
+      // Start the app by letting the user pick a role.
       home: const RoleSelectionPage(),
     );
   }

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -4,8 +4,10 @@ import 'package:intl/intl.dart';
 
 import '../models/appointment.dart';
 import '../models/service_type.dart';
+import '../models/user_role.dart';
 import '../utils/service_type_utils.dart';
 import '../services/appointment_service.dart';
+import '../services/role_provider.dart';
 import 'edit_appointment_page.dart';
 import 'edit_client_page.dart';
 
@@ -15,24 +17,26 @@ class AppointmentsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
+    final role = context.watch<RoleProvider>().selectedRole;
     final appointments = service.appointments;
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Appointments'),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.person),
-            tooltip: 'Clients',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const EditClientPage(),
-                ),
-              );
-            },
-          ),
+          if (role == UserRole.professional)
+            IconButton(
+              icon: const Icon(Icons.person),
+              tooltip: 'Clients',
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const EditClientPage(),
+                  ),
+                );
+              },
+            ),
         ],
       ),
       body: ListView.builder(
@@ -56,32 +60,38 @@ class AppointmentsPage extends StatelessWidget {
                     appt.dateTime.toLocal(),
                   ),
             ),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => EditAppointmentPage(appointment: appt),
-                ),
-              );
-            },
-            trailing: IconButton(
-              icon: const Icon(Icons.delete),
-              onPressed: () => service.deleteAppointment(appt.id),
-            ),
+            onTap: role == UserRole.professional
+                ? () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => EditAppointmentPage(appointment: appt),
+                      ),
+                    );
+                  }
+                : null,
+            trailing: role == UserRole.professional
+                ? IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () => service.deleteAppointment(appt.id),
+                  )
+                : null,
           );
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => const EditAppointmentPage(),
-            ),
-          );
-        },
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: role == UserRole.professional
+          ? FloatingActionButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const EditAppointmentPage(),
+                  ),
+                );
+              },
+              child: const Icon(Icons.add),
+            )
+          : null,
     );
   }
 }

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -3,7 +3,9 @@ import 'package:provider/provider.dart';
 
 import '../models/appointment.dart';
 import '../models/service_type.dart';
+import '../models/user_role.dart';
 import '../services/appointment_service.dart';
+import '../services/role_provider.dart';
 
 class EditAppointmentPage extends StatefulWidget {
   final Appointment? appointment;
@@ -30,9 +32,18 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
 
   @override
   Widget build(BuildContext context) {
+    final role = context.watch<RoleProvider>().selectedRole;
     final service = context.watch<AppointmentService>();
     final clients = service.clients;
     final isEditing = widget.appointment != null;
+
+    if (role != UserRole.professional) {
+      return const Scaffold(
+        body: Center(
+          child: Text('Available only for professionals'),
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/edit_client_page.dart
+++ b/lib/screens/edit_client_page.dart
@@ -2,15 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/client.dart';
+import '../models/user_role.dart';
 import '../services/appointment_service.dart';
+import '../services/role_provider.dart';
 
 class EditClientPage extends StatelessWidget {
   const EditClientPage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final role = context.watch<RoleProvider>().selectedRole;
     final service = context.watch<AppointmentService>();
     final clients = service.clients;
+
+    if (role != UserRole.professional) {
+      return const Scaffold(
+        body: Center(
+          child: Text('Available only for professionals'),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Clients'),


### PR DESCRIPTION
## Summary
- Start app at a role selection screen to choose customer or professional.
- Redirect customers to the existing welcome experience and professionals straight to appointments.
- Hide appointment and client editing actions when not in professional mode.

## Testing
- `dart format lib/main.dart lib/screens/appointments_page.dart lib/screens/edit_client_page.dart lib/screens/edit_appointment_page.dart` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a88b760832baefb789512ef099b