### PR TITLE
Handle unknown service types with default values

### DIFF
--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -10,6 +10,8 @@ String serviceTypeLabel(ServiceType type) {
       return 'Hairdresser';
     case ServiceType.nails:
       return 'Nails';
+    default:
+      return 'Unknown';
   }
 }
 
@@ -21,6 +23,8 @@ IconData serviceTypeIcon(ServiceType type) {
       return Icons.brush;
     case ServiceType.nails:
       return Icons.spa;
+    default:
+      return Icons.help_outline;
   }
 }
 
@@ -32,5 +36,7 @@ Color serviceTypeColor(ServiceType type) {
       return Colors.purple;
     case ServiceType.nails:
       return Colors.pink;
+    default:
+      return Colors.grey;
   }
 }


### PR DESCRIPTION
## Summary
- prevent null returns for unsupported service types by adding default cases
- show placeholder label, icon, and color when a service type is unrecognized

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a6283a1a4832bb4726902185e5598