### PR TITLE
Handle appointments when clients are removed

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -35,6 +35,19 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
     final role = context.watch<RoleProvider>().selectedRole;
     final service = context.watch<AppointmentService>();
     final clients = service.clients;
+    if (_selectedClientId != null &&
+        !clients.any((c) => c.id == _selectedClientId)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        setState(() => _selectedClientId = null);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+                'Previously selected client was removed. Please choose another.'),
+          ),
+        );
+      });
+    }
     final isEditing = widget.appointment != null;
 
     if (role != UserRole.professional) {

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -65,8 +65,25 @@ class AppointmentService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> deleteClient(String id) async {
+  Future<void> deleteClient(String id, {String? reassignedClientId}) async {
     _ensureInitialized();
+
+    final affected = _appointmentsBox.values
+        .map(Appointment.fromMap)
+        .where((a) => a.clientId == id)
+        .toList();
+
+    if (reassignedClientId != null) {
+      for (final appt in affected) {
+        final updated = appt.copyWith(clientId: reassignedClientId);
+        await _appointmentsBox.put(updated.id, updated.toMap());
+      }
+    } else {
+      for (final appt in affected) {
+        await _appointmentsBox.delete(appt.id);
+      }
+    }
+
     await _clientsBox.delete(id);
     notifyListeners();
   }

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -81,9 +81,16 @@ void main() {
       expect(notified, isTrue);
     });
 
-    test('delete client removes client and notifies listeners', () async {
+    test('delete client removes client and related appointments', () async {
       final client = Client(id: 'c1', name: 'Alice');
+      final appointment = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
       await service.addClient(client);
+      await service.addAppointment(appointment);
 
       var notified = false;
       service.addListener(() => notified = true);
@@ -92,7 +99,30 @@ void main() {
 
       expect(service.getClient('c1'), isNull);
       expect(service.clients, isEmpty);
+      expect(service.getAppointment('a1'), isNull);
+      expect(service.appointments, isEmpty);
       expect(notified, isTrue);
+    });
+
+    test('delete client reassigns appointments when id provided', () async {
+      final c1 = Client(id: 'c1', name: 'Alice');
+      final c2 = Client(id: 'c2', name: 'Bob');
+      final appointment = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+      await service.addClient(c1);
+      await service.addClient(c2);
+      await service.addAppointment(appointment);
+
+      await service.deleteClient('c1', reassignedClientId: 'c2');
+
+      final updated = service.getAppointment('a1');
+      expect(updated?.clientId, 'c2');
+      expect(service.getClient('c1'), isNull);
+      expect(service.clients.length, 1);
     });
   });
 

--- a/test/widget/appointments_page_test.dart
+++ b/test/widget/appointments_page_test.dart
@@ -39,7 +39,13 @@ class FakeAppointmentService extends ChangeNotifier implements AppointmentServic
   }
 
   @override
-  Future<void> deleteClient(String id) async {
+  Future<void> deleteClient(String id, {String? reassignedClientId}) async {
+    if (reassignedClientId != null) {
+      _appointments.updateAll((key, appt) =>
+          appt.clientId == id ? appt.copyWith(clientId: reassignedClientId) : appt);
+    } else {
+      _appointments.removeWhere((key, appt) => appt.clientId == id);
+    }
     _clients.remove(id);
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- Delete or optionally reassign appointments when a client is removed
- Ensure appointment editor clears selection if chosen client no longer exists
- Add tests for client deletion behavior

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a655c93f0832bbccb2bbb9fb2fe35