### PR TITLE
Add ServiceProvider model and tests

### DIFF
--- a/lib/models/service_provider.dart
+++ b/lib/models/service_provider.dart
@@ -1,0 +1,64 @@
+import 'service_type.dart';
+
+/// Represents a service provider available for bookings.
+class ServiceProvider {
+  /// Unique identifier for the service provider.
+  final String id;
+
+  /// Display name of the provider.
+  final String name;
+
+  /// The type of service this provider offers.
+  final ServiceType serviceType;
+
+  /// Creates a new [ServiceProvider] instance.
+  ServiceProvider({
+    required this.id,
+    required this.name,
+    required this.serviceType,
+  });
+
+  /// Returns a copy of this provider with the provided values replaced.
+  ServiceProvider copyWith({
+    String? id,
+    String? name,
+    ServiceType? serviceType,
+  }) {
+    return ServiceProvider(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      serviceType: serviceType ?? this.serviceType,
+    );
+  }
+
+  /// Creates a [ServiceProvider] from a JSON-compatible [map].
+  factory ServiceProvider.fromMap(Map<String, dynamic> map) {
+    return ServiceProvider(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      serviceType: ServiceType.values.byName(map['serviceType'] as String),
+    );
+  }
+
+  /// Converts this provider to a JSON-compatible map.
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'serviceType': serviceType.name,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ServiceProvider &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          serviceType == other.serviceType;
+
+  @override
+  int get hashCode => id.hashCode ^ name.hashCode ^ serviceType.hashCode;
+}
+

--- a/test/models/service_provider_test.dart
+++ b/test/models/service_provider_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vogue_vault/models/service_provider.dart';
+import 'package:vogue_vault/models/service_type.dart';
+
+void main() {
+  group('ServiceProvider serialization', () {
+    test('toMap and fromMap produce equivalent objects', () {
+      final provider = ServiceProvider(
+        id: 's1',
+        name: 'Bob',
+        serviceType: ServiceType.barber,
+      );
+      final map = provider.toMap();
+      final from = ServiceProvider.fromMap(map);
+
+      expect(from.id, provider.id);
+      expect(from.name, provider.name);
+      expect(from.serviceType, provider.serviceType);
+    });
+
+    test('fromMap validates required data', () {
+      final missing = {'id': 's1'};
+      expect(() => ServiceProvider.fromMap(missing), throwsA(isA<TypeError>()));
+    });
+  });
+
+  group('ServiceProvider equality', () {
+    test('providers with same values are equal', () {
+      final p1 = ServiceProvider(
+        id: 's1',
+        name: 'Bob',
+        serviceType: ServiceType.barber,
+      );
+      final p2 = ServiceProvider(
+        id: 's1',
+        name: 'Bob',
+        serviceType: ServiceType.barber,
+      );
+
+      expect(p1, equals(p2));
+      expect(p1.hashCode, equals(p2.hashCode));
+    });
+
+    test('providers with different values are not equal', () {
+      final p1 = ServiceProvider(
+        id: 's1',
+        name: 'Bob',
+        serviceType: ServiceType.barber,
+      );
+      final p2 = ServiceProvider(
+        id: 's2',
+        name: 'Bob',
+        serviceType: ServiceType.barber,
+      );
+
+      expect(p1, isNot(equals(p2)));
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add ServiceProvider model with id, name, and service type
- cover ServiceProvider serialization and equality with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab8c25060832bb385ec61acd9004d