### PR TITLE
Add provider management to appointment service

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -3,13 +3,16 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/appointment.dart';
 import '../models/client.dart';
+import '../models/service_provider.dart';
 
 class AppointmentService extends ChangeNotifier {
   static const _appointmentsBoxName = 'appointments';
   static const _clientsBoxName = 'clients';
+  static const _providersBoxName = 'providers';
 
   late Box<Map<String, dynamic>> _appointmentsBox;
   late Box<Map<String, dynamic>> _clientsBox;
+  late Box<Map<String, dynamic>> _providersBox;
 
   bool _initialized = false;
   bool get isInitialized => _initialized;
@@ -20,6 +23,8 @@ class AppointmentService extends ChangeNotifier {
         await Hive.openBox<Map<String, dynamic>>(_appointmentsBoxName);
     _clientsBox =
         await Hive.openBox<Map<String, dynamic>>(_clientsBoxName);
+    _providersBox =
+        await Hive.openBox<Map<String, dynamic>>(_providersBoxName);
     _initialized = true;
   }
 
@@ -39,6 +44,11 @@ class AppointmentService extends ChangeNotifier {
     return _clientsBox.values.map(Client.fromMap).toList();
   }
 
+  List<ServiceProvider> get providers {
+    if (!_initialized) return [];
+    return _providersBox.values.map(ServiceProvider.fromMap).toList();
+  }
+
   Client? getClient(String id) {
     _ensureInitialized();
     final map = _clientsBox.get(id);
@@ -51,6 +61,13 @@ class AppointmentService extends ChangeNotifier {
     final map = _appointmentsBox.get(id);
     if (map == null) return null;
     return Appointment.fromMap(map);
+  }
+
+  ServiceProvider? getProvider(String id) {
+    _ensureInitialized();
+    final map = _providersBox.get(id);
+    if (map == null) return null;
+    return ServiceProvider.fromMap(map);
   }
 
   Future<void> addClient(Client client) async {
@@ -88,6 +105,24 @@ class AppointmentService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> addProvider(ServiceProvider provider) async {
+    _ensureInitialized();
+    await _providersBox.put(provider.id, provider.toMap());
+    notifyListeners();
+  }
+
+  Future<void> updateProvider(ServiceProvider provider) async {
+    _ensureInitialized();
+    await _providersBox.put(provider.id, provider.toMap());
+    notifyListeners();
+  }
+
+  Future<void> deleteProvider(String id) async {
+    _ensureInitialized();
+    await _providersBox.delete(id);
+    notifyListeners();
+  }
+
   Future<void> addAppointment(Appointment appointment) async {
     _ensureInitialized();
     await _appointmentsBox.put(appointment.id, appointment.toMap());
@@ -111,6 +146,7 @@ class AppointmentService extends ChangeNotifier {
     if (_initialized) {
       _appointmentsBox.close();
       _clientsBox.close();
+      _providersBox.close();
     }
     super.dispose();
   }

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -5,6 +5,7 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:hive/hive.dart';
 import 'package:vogue_vault/models/appointment.dart';
 import 'package:vogue_vault/models/client.dart';
+import 'package:vogue_vault/models/service_provider.dart';
 import 'package:vogue_vault/models/service_type.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 
@@ -51,6 +52,61 @@ void main() {
     service.dispose();
     await Hive.deleteFromDisk();
     await tempDir.delete(recursive: true);
+  });
+
+  group('Provider operations', () {
+    test('add provider stores provider and notifies listeners', () async {
+      final provider = ServiceProvider(
+        id: 'p1',
+        name: 'Jane',
+        serviceType: ServiceType.barber,
+      );
+      var notified = false;
+      service.addListener(() => notified = true);
+
+      await service.addProvider(provider);
+
+      expect(service.getProvider('p1'), equals(provider));
+      expect(service.providers, contains(provider));
+      expect(notified, isTrue);
+    });
+
+    test('update provider updates data and notifies listeners', () async {
+      final provider = ServiceProvider(
+        id: 'p1',
+        name: 'Jane',
+        serviceType: ServiceType.barber,
+      );
+      await service.addProvider(provider);
+
+      final updated = provider.copyWith(name: 'Jane Updated');
+      var notified = false;
+      service.addListener(() => notified = true);
+
+      await service.updateProvider(updated);
+
+      expect(service.getProvider('p1'), equals(updated));
+      expect(service.providers.length, 1);
+      expect(notified, isTrue);
+    });
+
+    test('delete provider removes provider and notifies listeners', () async {
+      final provider = ServiceProvider(
+        id: 'p1',
+        name: 'Jane',
+        serviceType: ServiceType.barber,
+      );
+      await service.addProvider(provider);
+
+      var notified = false;
+      service.addListener(() => notified = true);
+
+      await service.deleteProvider('p1');
+
+      expect(service.getProvider('p1'), isNull);
+      expect(service.providers, isEmpty);
+      expect(notified, isTrue);
+    });
   });
 
   group('Client operations', () {


### PR DESCRIPTION
## Summary
- Add Hive `providers` box to `AppointmentService`
- Expose provider list and CRUD operations
- Test provider CRUD flows in appointment service tests

## Testing
- `flutter test test/services/appointment_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9acfbac832b9645a31994ea2bde