### PR TITLE
Add providerId support for appointments

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -8,6 +8,9 @@ class Appointment {
   /// Identifier of the client booking the appointment.
   final String clientId;
 
+  /// Identifier of the service provider handling the appointment.
+  final String providerId;
+
   /// The type of service being scheduled.
   final ServiceType service;
 
@@ -18,6 +21,7 @@ class Appointment {
   Appointment({
     required this.id,
     required this.clientId,
+    required this.providerId,
     required this.service,
     required this.dateTime,
   });
@@ -26,12 +30,14 @@ class Appointment {
   Appointment copyWith({
     String? id,
     String? clientId,
+    String? providerId,
     ServiceType? service,
     DateTime? dateTime,
   }) {
     return Appointment(
       id: id ?? this.id,
       clientId: clientId ?? this.clientId,
+      providerId: providerId ?? this.providerId,
       service: service ?? this.service,
       dateTime: dateTime ?? this.dateTime,
     );
@@ -42,6 +48,7 @@ class Appointment {
     return Appointment(
       id: map['id'] as String,
       clientId: map['clientId'] as String,
+      providerId: map['providerId'] as String,
       service: ServiceType.values.byName(map['service'] as String),
       dateTime: DateTime.parse(map['dateTime'] as String),
     );
@@ -52,6 +59,7 @@ class Appointment {
     return {
       'id': id,
       'clientId': clientId,
+      'providerId': providerId,
       'service': service.name,
       'dateTime': dateTime.toIso8601String(),
     };
@@ -64,10 +72,14 @@ class Appointment {
           runtimeType == other.runtimeType &&
           id == other.id &&
           clientId == other.clientId &&
+          providerId == other.providerId &&
           service == other.service &&
           dateTime == other.dateTime;
 
   @override
-  int get hashCode =>
-      id.hashCode ^ clientId.hashCode ^ service.hashCode ^ dateTime.hashCode;
+  int get hashCode => id.hashCode ^
+      clientId.hashCode ^
+      providerId.hashCode ^
+      service.hashCode ^
+      dateTime.hashCode;
 }

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -146,6 +146,9 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                   final newAppt = Appointment(
                     id: id,
                     clientId: _selectedClientId!,
+                    providerId: service.providers.isNotEmpty
+                        ? service.providers.first.id
+                        : '',
                     service: _service,
                     dateTime: _dateTime,
                   );

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -60,7 +60,11 @@ class AppointmentService extends ChangeNotifier {
     _ensureInitialized();
     final map = _appointmentsBox.get(id);
     if (map == null) return null;
-    return Appointment.fromMap(map);
+    // Ensure providerId is available for older stored appointments.
+    return Appointment.fromMap({
+      ...map,
+      'providerId': map['providerId'] ?? '',
+    });
   }
 
   ServiceProvider? getProvider(String id) {
@@ -125,12 +129,14 @@ class AppointmentService extends ChangeNotifier {
 
   Future<void> addAppointment(Appointment appointment) async {
     _ensureInitialized();
+    // providerId is persisted via the appointment's toMap representation.
     await _appointmentsBox.put(appointment.id, appointment.toMap());
     notifyListeners();
   }
 
   Future<void> updateAppointment(Appointment appointment) async {
     _ensureInitialized();
+    // providerId is persisted via the appointment's toMap representation.
     await _appointmentsBox.put(appointment.id, appointment.toMap());
     notifyListeners();
   }

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -8,6 +8,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -16,6 +17,7 @@ void main() {
 
       expect(from.id, appointment.id);
       expect(from.clientId, appointment.clientId);
+      expect(from.providerId, appointment.providerId);
       expect(from.service, appointment.service);
       expect(from.dateTime, appointment.dateTime);
     });
@@ -27,6 +29,7 @@ void main() {
       final invalidDate = {
         'id': 'a1',
         'clientId': 'c1',
+        'providerId': 'p1',
         'service': 'barber',
         'dateTime': 'invalid',
       };
@@ -39,12 +42,14 @@ void main() {
       final a1 = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
       final a2 = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -57,12 +62,14 @@ void main() {
       final a1 = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
       final a2 = Appointment(
         id: 'a2',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -142,6 +142,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -166,6 +167,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -187,6 +189,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -204,6 +207,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -227,6 +231,7 @@ void main() {
       final appointment = Appointment(
         id: 'a1',
         clientId: 'c1',
+        providerId: 'p1',
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );

--- a/test/widget/appointments_page_test.dart
+++ b/test/widget/appointments_page_test.dart
@@ -4,15 +4,20 @@ import 'package:provider/provider.dart';
 import 'package:vogue_vault/models/appointment.dart';
 import 'package:vogue_vault/models/client.dart';
 import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/models/service_provider.dart';
 import 'package:vogue_vault/screens/appointments_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 
 class FakeAppointmentService extends ChangeNotifier implements AppointmentService {
   final Map<String, Appointment> _appointments = {};
   final Map<String, Client> _clients = {};
+  final Map<String, ServiceProvider> _providers = {};
 
   @override
   Future<void> init() async {}
+
+  @override
+  bool get isInitialized => true;
 
   @override
   List<Appointment> get appointments => _appointments.values.toList();
@@ -21,10 +26,16 @@ class FakeAppointmentService extends ChangeNotifier implements AppointmentServic
   List<Client> get clients => _clients.values.toList();
 
   @override
+  List<ServiceProvider> get providers => _providers.values.toList();
+
+  @override
   Client? getClient(String id) => _clients[id];
 
   @override
   Appointment? getAppointment(String id) => _appointments[id];
+
+  @override
+  ServiceProvider? getProvider(String id) => _providers[id];
 
   @override
   Future<void> addClient(Client client) async {
@@ -47,6 +58,24 @@ class FakeAppointmentService extends ChangeNotifier implements AppointmentServic
       _appointments.removeWhere((key, appt) => appt.clientId == id);
     }
     _clients.remove(id);
+    notifyListeners();
+  }
+
+  @override
+  Future<void> addProvider(ServiceProvider provider) async {
+    _providers[provider.id] = provider;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateProvider(ServiceProvider provider) async {
+    _providers[provider.id] = provider;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> deleteProvider(String id) async {
+    _providers.remove(id);
     notifyListeners();
   }
 
@@ -76,6 +105,7 @@ void main() {
     final appointment = Appointment(
       id: 'a1',
       clientId: 'c1',
+      providerId: 'p1',
       service: ServiceType.barber,
       dateTime: DateTime(2023, 9, 10, 10),
     );


### PR DESCRIPTION
## Summary
- include providerId on Appointment model with full serialization and equality updates
- persist providerId in AppointmentService and add fallback when missing
- update UI and tests to handle providerId

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689abc9e08c8832bb8e388914c144ce0