### PR TITLE
Add provider management screen and tests

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -10,6 +10,7 @@ import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
 import 'edit_appointment_page.dart';
 import 'edit_client_page.dart';
+import 'edit_provider_page.dart';
 
 class AppointmentsPage extends StatelessWidget {
   const AppointmentsPage({super.key});
@@ -33,6 +34,19 @@ class AppointmentsPage extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (_) => const EditClientPage(),
+                  ),
+                );
+              },
+            ),
+          if (role == UserRole.professional)
+            IconButton(
+              icon: const Icon(Icons.work),
+              tooltip: 'Providers',
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const EditProviderPage(),
                   ),
                 );
               },

--- a/lib/screens/edit_provider_page.dart
+++ b/lib/screens/edit_provider_page.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/service_provider.dart';
+import '../models/service_type.dart';
+import '../models/user_role.dart';
+import '../services/appointment_service.dart';
+import '../services/role_provider.dart';
+
+class EditProviderPage extends StatelessWidget {
+  const EditProviderPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final role = context.watch<RoleProvider>().selectedRole;
+    final service = context.watch<AppointmentService>();
+    final providers = service.providers;
+
+    if (role != UserRole.professional) {
+      return const Scaffold(
+        body: Center(
+          child: Text('Available only for professionals'),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Providers'),
+      ),
+      body: ListView.builder(
+        itemCount: providers.length,
+        itemBuilder: (context, index) {
+          final provider = providers[index];
+          return ListTile(
+            title: Text(provider.name),
+            subtitle: Text(provider.serviceType.name),
+            onTap: () => _showProviderDialog(context, provider: provider),
+            trailing: IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => service.deleteProvider(provider.id),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showProviderDialog(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _showProviderDialog(BuildContext context,
+      {ServiceProvider? provider}) async {
+    final nameController = TextEditingController(text: provider?.name ?? '');
+    final formKey = GlobalKey<FormState>();
+    var selectedType = provider?.serviceType ?? ServiceType.barber;
+
+    await showDialog(
+      context: context,
+      builder: (_) => StatefulBuilder(
+        builder: (context, setState) {
+          return AlertDialog(
+            title: Text(provider == null ? 'New Provider' : 'Edit Provider'),
+            content: Form(
+              key: formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: nameController,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    validator: (value) => value == null || value.trim().isEmpty
+                        ? 'Please enter a name'
+                        : null,
+                  ),
+                  DropdownButtonFormField<ServiceType>(
+                    key: const Key('serviceTypeDropdown'),
+                    value: selectedType,
+                    decoration: const InputDecoration(labelText: 'Service Type'),
+                    items: ServiceType.values
+                        .map(
+                          (s) => DropdownMenuItem<ServiceType>(
+                            value: s,
+                            child: Text(s.name),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (value) => setState(() => selectedType = value!),
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  if (!formKey.currentState!.validate()) return;
+                  final service = context.read<AppointmentService>();
+                  final id = provider?.id ??
+                      DateTime.now().millisecondsSinceEpoch.toString();
+                  final newProvider = ServiceProvider(
+                    id: id,
+                    name: nameController.text,
+                    serviceType: selectedType,
+                  );
+                  if (provider == null) {
+                    await service.addProvider(newProvider);
+                  } else {
+                    await service.updateProvider(newProvider);
+                  }
+                  Navigator.pop(context);
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+
+    nameController.dispose();
+  }
+}
+

--- a/test/widget/appointments_page_test.dart
+++ b/test/widget/appointments_page_test.dart
@@ -7,6 +7,8 @@ import 'package:vogue_vault/models/service_type.dart';
 import 'package:vogue_vault/models/service_provider.dart';
 import 'package:vogue_vault/screens/appointments_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/models/user_role.dart';
+import 'package:vogue_vault/services/role_provider.dart';
 
 class FakeAppointmentService extends ChangeNotifier implements AppointmentService {
   final Map<String, Appointment> _appointments = {};
@@ -112,9 +114,13 @@ void main() {
     await service.addClient(client);
     await service.addAppointment(appointment);
 
+    final roleProvider = RoleProvider()..selectedRole = UserRole.professional;
     await tester.pumpWidget(
-      ChangeNotifierProvider<AppointmentService>.value(
-        value: service,
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AppointmentService>.value(value: service),
+          ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
+        ],
         child: const MaterialApp(home: AppointmentsPage()),
       ),
     );

--- a/test/widget/edit_provider_page_test.dart
+++ b/test/widget/edit_provider_page_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/models/service_provider.dart';
+import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/models/user_role.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/client.dart';
+import 'package:vogue_vault/screens/appointments_page.dart';
+import 'package:vogue_vault/screens/edit_provider_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/role_provider.dart';
+
+class FakeAppointmentService extends ChangeNotifier implements AppointmentService {
+  final Map<String, ServiceProvider> _providers = {};
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  List<Appointment> get appointments => [];
+
+  @override
+  List<Client> get clients => [];
+
+  @override
+  List<ServiceProvider> get providers => _providers.values.toList();
+
+  @override
+  Client? getClient(String id) => null;
+
+  @override
+  Appointment? getAppointment(String id) => null;
+
+  @override
+  ServiceProvider? getProvider(String id) => _providers[id];
+
+  @override
+  Future<void> addClient(Client client) async {}
+
+  @override
+  Future<void> updateClient(Client client) async {}
+
+  @override
+  Future<void> deleteClient(String id, {String? reassignedClientId}) async {}
+
+  @override
+  Future<void> addProvider(ServiceProvider provider) async {
+    _providers[provider.id] = provider;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateProvider(ServiceProvider provider) async {
+    _providers[provider.id] = provider;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> deleteProvider(String id) async {
+    _providers.remove(id);
+    notifyListeners();
+  }
+
+  @override
+  Future<void> addAppointment(Appointment appointment) async {}
+
+  @override
+  Future<void> updateAppointment(Appointment appointment) async {}
+
+  @override
+  Future<void> deleteAppointment(String id) async {}
+}
+
+void main() {
+  testWidgets('Providers can be added, edited, and deleted', (tester) async {
+    final service = FakeAppointmentService();
+    final roleProvider = RoleProvider()..selectedRole = UserRole.professional;
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AppointmentService>.value(value: service),
+          ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
+        ],
+        child: const MaterialApp(home: EditProviderPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Add provider
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(find.text('New Provider'), findsOneWidget);
+    await tester.enterText(find.byType(TextFormField), 'Bob');
+    await tester.tap(find.byKey(const Key('serviceTypeDropdown')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('hairdresser').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+    expect(find.text('Bob'), findsOneWidget);
+
+    // Edit provider
+    await tester.tap(find.text('Bob'));
+    await tester.pumpAndSettle();
+    expect(find.text('Edit Provider'), findsOneWidget);
+    await tester.enterText(find.byType(TextFormField), 'Bobby');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+    expect(find.text('Bobby'), findsOneWidget);
+    expect(find.text('Bob'), findsNothing);
+
+    // Delete provider
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pumpAndSettle();
+    expect(find.text('Bobby'), findsNothing);
+  });
+
+  testWidgets('Appointments page navigates to providers', (tester) async {
+    final service = FakeAppointmentService();
+    final roleProvider = RoleProvider()..selectedRole = UserRole.professional;
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AppointmentService>.value(value: service),
+          ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
+        ],
+        child: const MaterialApp(home: AppointmentsPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Providers'));
+    await tester.pumpAndSettle();
+    expect(find.text('Providers'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Add `EditProviderPage` to manage service providers with service-type dropdown
- Link provider management from appointments page for professionals
- Test provider CRUD and navigation

## Testing
- `dart format lib/screens/edit_provider_page.dart lib/screens/appointments_page.dart test/widget/appointments_page_test.dart test/widget/edit_provider_page_test.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689abe51f048832baba038d0dbc28988