### PR TITLE
Handle provider appointment reassignment on delete

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -121,8 +121,25 @@ class AppointmentService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> deleteProvider(String id) async {
+  Future<void> deleteProvider(String id, {String? reassignedProviderId}) async {
     _ensureInitialized();
+
+    final affected = _appointmentsBox.values
+        .map(Appointment.fromMap)
+        .where((a) => a.providerId == id)
+        .toList();
+
+    if (reassignedProviderId != null) {
+      for (final appt in affected) {
+        final updated = appt.copyWith(providerId: reassignedProviderId);
+        await _appointmentsBox.put(updated.id, updated.toMap());
+      }
+    } else {
+      for (final appt in affected) {
+        await _appointmentsBox.delete(appt.id);
+      }
+    }
+
     await _providersBox.delete(id);
     notifyListeners();
   }

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -90,13 +90,21 @@ void main() {
       expect(notified, isTrue);
     });
 
-    test('delete provider removes provider and notifies listeners', () async {
+    test('delete provider removes provider and related appointments', () async {
       final provider = ServiceProvider(
         id: 'p1',
         name: 'Jane',
         serviceType: ServiceType.barber,
       );
+      final appointment = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        providerId: 'p1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
       await service.addProvider(provider);
+      await service.addAppointment(appointment);
 
       var notified = false;
       service.addListener(() => notified = true);
@@ -105,7 +113,39 @@ void main() {
 
       expect(service.getProvider('p1'), isNull);
       expect(service.providers, isEmpty);
+      expect(service.getAppointment('a1'), isNull);
+      expect(service.appointments, isEmpty);
       expect(notified, isTrue);
+    });
+
+    test('delete provider reassigns appointments when id provided', () async {
+      final p1 = ServiceProvider(
+        id: 'p1',
+        name: 'Jane',
+        serviceType: ServiceType.barber,
+      );
+      final p2 = ServiceProvider(
+        id: 'p2',
+        name: 'John',
+        serviceType: ServiceType.barber,
+      );
+      final appointment = Appointment(
+        id: 'a1',
+        clientId: 'c1',
+        providerId: 'p1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 10, 0),
+      );
+      await service.addProvider(p1);
+      await service.addProvider(p2);
+      await service.addAppointment(appointment);
+
+      await service.deleteProvider('p1', reassignedProviderId: 'p2');
+
+      final updated = service.getAppointment('a1');
+      expect(updated?.providerId, 'p2');
+      expect(service.getProvider('p1'), isNull);
+      expect(service.providers.length, 1);
     });
   });
 


### PR DESCRIPTION
## Summary
- deleteProvider now reassigns or deletes related appointments similar to deleteClient
- add tests covering provider appointment deletion and reassignment

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689b3c270664832b9feb728bed123366