### PR TITLE
Enable switching user roles and keep selection in navigation stack

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -11,6 +11,7 @@ import '../services/role_provider.dart';
 import 'edit_appointment_page.dart';
 import 'edit_client_page.dart';
 import 'edit_provider_page.dart';
+import 'role_selection_page.dart';
 
 class AppointmentsPage extends StatelessWidget {
   const AppointmentsPage({super.key});
@@ -25,6 +26,20 @@ class AppointmentsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Appointments'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.switch_account),
+            tooltip: 'Switch Role',
+            onPressed: () {
+              context.read<RoleProvider>().clearRole();
+              Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const RoleSelectionPage(),
+                ),
+                (route) => false,
+              );
+            },
+          ),
           if (role == UserRole.professional)
             IconButton(
               icon: const Icon(Icons.person),

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -32,7 +32,7 @@ class RoleSelectionPage extends StatelessWidget {
                 child: ElevatedButton(
                   onPressed: () {
                     context.read<RoleProvider>().selectedRole = UserRole.customer;
-                    Navigator.pushReplacement(
+                    Navigator.push(
                       context,
                       MaterialPageRoute(
                         builder: (_) => const WelcomePage(),
@@ -48,7 +48,7 @@ class RoleSelectionPage extends StatelessWidget {
                 child: ElevatedButton(
                   onPressed: () {
                     context.read<RoleProvider>().selectedRole = UserRole.professional;
-                    Navigator.pushReplacement(
+                    Navigator.push(
                       context,
                       MaterialPageRoute(
                         builder: (_) => const AppointmentsPage(),

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../models/service_type.dart';
 import '../utils/service_type_utils.dart';
+import '../services/role_provider.dart';
 import 'appointments_page.dart';
 import 'provider_selection_page.dart';
+import 'role_selection_page.dart';
 
 class WelcomePage extends StatelessWidget {
   const WelcomePage({super.key});
@@ -13,6 +16,22 @@ class WelcomePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Welcome'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.switch_account),
+            tooltip: 'Switch Role',
+            onPressed: () {
+              context.read<RoleProvider>().clearRole();
+              Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const RoleSelectionPage(),
+                ),
+                (route) => false,
+              );
+            },
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -11,4 +11,9 @@ class RoleProvider extends ChangeNotifier {
     _selectedRole = role;
     notifyListeners();
   }
+
+  void clearRole() {
+    _selectedRole = null;
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
## Summary
- Add `clearRole()` to `RoleProvider` to reset user role
- Use `Navigator.push` on role selection to keep screen in stack
- Add "Switch Role" actions on Welcome and Appointments pages that clear role and return to selection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b47abd46c832b861df3f49d00511d