### PR TITLE
Filter providers by service type

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -38,7 +38,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
     final clients = service.clients;
-    final providers = service.providers;
+    final providers = service.providersFor(_service);
     if (_selectedClientId != null &&
         !clients.any((c) => c.id == _selectedClientId)) {
       _selectedClientId = null;
@@ -60,7 +60,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text(
-                'Previously selected provider was removed. Please choose another.'),
+                'Previously selected provider was removed or unavailable. Please choose another.'),
           ),
         );
       });
@@ -126,8 +126,16 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                     )
                     .toList(),
                 onChanged: (value) {
+                  if (value == null) return;
+                  final availableProviders =
+                      context.read<AppointmentService>().providersFor(value);
                   setState(() {
-                    _service = value!;
+                    _service = value;
+                    if (_selectedProviderId != null &&
+                        !availableProviders
+                            .any((p) => p.id == _selectedProviderId)) {
+                      _selectedProviderId = null;
+                    }
                   });
                 },
                 validator: (value) =>

--- a/lib/screens/provider_selection_page.dart
+++ b/lib/screens/provider_selection_page.dart
@@ -15,7 +15,7 @@ class ProviderSelectionPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
-    final providers = service.providers;
+    final providers = service.providersFor(serviceType);
 
     return Scaffold(
       appBar: AppBar(
@@ -42,6 +42,17 @@ class ProviderSelectionPage extends StatelessWidget {
                   ),
                   title: Text(provider.name),
                   onTap: () {
+                    final validProviders =
+                        service.providersFor(serviceType);
+                    if (!validProviders.any((p) => p.id == provider.id)) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text(
+                              'Selected provider no longer offers this service.'),
+                        ),
+                      );
+                      return;
+                    }
                     Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/appointment.dart';
+import '../models/service_type.dart';
 import '../models/user_profile.dart';
 import '../models/user_role.dart';
 
@@ -52,6 +53,9 @@ class AppointmentService extends ChangeNotifier {
 
   List<UserProfile> get providers =>
       users.where((u) => u.roles.contains(UserRole.professional)).toList();
+
+  List<UserProfile> providersFor(ServiceType type) =>
+      providers.where((p) => p.services.contains(type)).toList();
 
   UserProfile? getUser(String id) {
     _ensureInitialized();


### PR DESCRIPTION
## Summary
- Add AppointmentService.providersFor to return professionals for a given ServiceType
- Use providersFor in provider selection and edit appointment screens to keep provider choices in sync with selected service
- Validate navigation to ensure providers still offer requested service

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689b53d3a268832b99004fd6668aade1