### PR TITLE
Add basic authentication flow with session persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'screens/role_selection_page.dart';
+import 'screens/auth_page.dart';
 import 'services/appointment_service.dart';
+import 'services/auth_service.dart';
 import 'services/role_provider.dart';
 
 Future<void> main() async {
@@ -12,12 +13,17 @@ Future<void> main() async {
 
   final appointmentService = AppointmentService();
   await appointmentService.init();
+  final authService = AuthService();
+  await authService.init();
 
   runApp(
     MultiProvider(
       providers: [
         ChangeNotifierProvider<AppointmentService>.value(
           value: appointmentService,
+        ),
+        ChangeNotifierProvider<AuthService>.value(
+          value: authService,
         ),
         ChangeNotifierProvider<RoleProvider>(
           create: (_) => RoleProvider(),
@@ -38,8 +44,8 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      // Start the app by letting the user pick a role.
-      home: const RoleSelectionPage(),
+      // Start the app with authentication.
+      home: const AuthPage(),
     );
   }
 }

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/auth_service.dart';
+import 'role_selection_page.dart';
+
+class AuthPage extends StatefulWidget {
+  const AuthPage({super.key});
+
+  @override
+  State<AuthPage> createState() => _AuthPageState();
+}
+
+class _AuthPageState extends State<AuthPage> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _isLogin = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthService>();
+    if (auth.isLoggedIn) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => const RoleSelectionPage()),
+        );
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    final email = _emailController.text;
+    final password = _passwordController.text;
+    final auth = context.read<AuthService>();
+
+    bool success = false;
+    if (_isLogin) {
+      success = await auth.login(email, password);
+      if (!success) {
+        setState(() => _error = 'Invalid credentials');
+        return;
+      }
+    } else {
+      await auth.register(email, password);
+      success = true;
+    }
+
+    if (success && mounted) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const RoleSelectionPage()),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isLogin ? 'Sign In' : 'Register'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  _error!,
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.error),
+                ),
+              ],
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  child: Text(_isLogin ? 'Login' : 'Register'),
+                ),
+              ),
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    _isLogin = !_isLogin;
+                    _error = null;
+                  });
+                },
+                child: Text(_isLogin
+                    ? 'Create an account'
+                    : 'Have an account? Sign in'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+}
+

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/user_role.dart';
+import '../services/auth_service.dart';
 import '../services/role_provider.dart';
+import 'auth_page.dart';
 import 'appointments_page.dart';
 import 'welcome_page.dart';
 
@@ -13,9 +15,34 @@ class RoleSelectionPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final roles = context.watch<RoleProvider>().roles;
+    final auth = context.watch<AuthService>();
+
+    if (!auth.isLoggedIn) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => const AuthPage()),
+        );
+      });
+      return const SizedBox.shrink();
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Select Role'),
+        actions: [
+          IconButton(
+            onPressed: () {
+              context.read<AuthService>().logout();
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(builder: (_) => const AuthPage()),
+              );
+            },
+            icon: const Icon(Icons.logout),
+            tooltip: 'Logout',
+          ),
+        ],
       ),
       body: Center(
         child: Padding(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class AuthService extends ChangeNotifier {
+  static const _boxName = 'auth';
+  static const _usersKey = 'users';
+  static const _currentUserKey = 'currentUser';
+
+  late Box _box;
+  bool _initialized = false;
+
+  bool get isInitialized => _initialized;
+
+  Future<void> init() async {
+    _box = await Hive.openBox(_boxName);
+    _initialized = true;
+  }
+
+  void _ensureInitialized() {
+    if (!_initialized) {
+      throw StateError('AuthService has not been initialized.');
+    }
+  }
+
+  Map<String, String> get _users =>
+      Map<String, String>.from(_box.get(_usersKey, defaultValue: <String, String>{}));
+
+  String? get currentUser {
+    _ensureInitialized();
+    return _box.get(_currentUserKey) as String?;
+  }
+
+  bool get isLoggedIn => currentUser != null;
+
+  Future<bool> login(String email, String password) async {
+    _ensureInitialized();
+    final users = _users;
+    final storedPassword = users[email];
+    if (storedPassword == password) {
+      await _box.put(_currentUserKey, email);
+      notifyListeners();
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> register(String email, String password) async {
+    _ensureInitialized();
+    final users = _users;
+    users[email] = password;
+    await _box.put(_usersKey, users);
+    await _box.put(_currentUserKey, email);
+    notifyListeners();
+  }
+
+  Future<void> logout() async {
+    _ensureInitialized();
+    await _box.delete(_currentUserKey);
+    notifyListeners();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add AuthService to manage persistent login state and credentials
- create AuthPage with login and registration UI, redirecting to role selection after auth
- update RoleSelectionPage with logout button and auth guard
- wire AuthService into app startup and set AuthPage as home

## Testing
- `flutter format lib/services/auth_service.dart lib/screens/auth_page.dart lib/main.dart lib/screens/role_selection_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b55fe737c832baf96a354eb9089cc