### PR TITLE
Use unmodifiable roles set in RoleProvider

### DIFF
--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -4,10 +4,10 @@ import '../models/user_role.dart';
 
 class RoleProvider extends ChangeNotifier {
   UserRole? _selectedRole;
-  Set<UserRole> _roles = {UserRole.customer, UserRole.professional};
+  final Set<UserRole> _roles = {UserRole.customer, UserRole.professional};
 
   UserRole? get selectedRole => _selectedRole;
-  Set<UserRole> get roles => _roles;
+  Set<UserRole> get roles => Set.unmodifiable(_roles);
 
   set selectedRole(UserRole? role) {
     _selectedRole = role;
@@ -15,7 +15,19 @@ class RoleProvider extends ChangeNotifier {
   }
 
   void setRoles(Set<UserRole> roles) {
-    _roles = roles;
+    _roles
+      ..clear()
+      ..addAll(roles);
+    notifyListeners();
+  }
+
+  void addRole(UserRole role) {
+    _roles.add(role);
+    notifyListeners();
+  }
+
+  void removeRole(UserRole role) {
+    _roles.remove(role);
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- Expose roles as an unmodifiable set
- Restrict role mutations to provider methods only

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b66c62be8832ba70448b7f4c123d5