### PR TITLE
Add profile management screen and entry point

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -10,6 +10,7 @@ import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
 import 'edit_appointment_page.dart';
 import 'edit_user_page.dart';
+import 'profile_page.dart';
 import 'role_selection_page.dart';
 
 class AppointmentsPage extends StatelessWidget {
@@ -25,6 +26,18 @@ class AppointmentsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Appointments'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            tooltip: 'Profile',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const ProfilePage(),
+                ),
+              );
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.switch_account),
             tooltip: 'Switch Role',

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -6,6 +6,7 @@ import '../utils/service_type_utils.dart';
 import '../services/role_provider.dart';
 import 'appointments_page.dart';
 import 'provider_selection_page.dart';
+import 'profile_page.dart';
 import 'role_selection_page.dart';
 
 class WelcomePage extends StatelessWidget {
@@ -17,6 +18,18 @@ class WelcomePage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Welcome'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            tooltip: 'Profile',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const ProfilePage(),
+                ),
+              );
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.switch_account),
             tooltip: 'Switch Role',


### PR DESCRIPTION
## Summary
- add profile page to edit user name and photo
- add profile icon in main pages for easy access

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689b83318f6c832bb45f4d56d65050a5