### PR TITLE
refactor: remove MaterialApp material3 flag

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,6 @@ class MyApp extends StatelessWidget {
 
     return MaterialApp(
       title: 'Vogue Vault',
-      useMaterial3: true,
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: lightScheme,


### PR DESCRIPTION
## Summary
- remove deprecated `useMaterial3` argument from `MaterialApp`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb4ab3d74832b875d154191b05fd7