### PR TITLE
feat: support cross-platform avatar images

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
@@ -9,6 +7,7 @@ import '../models/user_role.dart';
 import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
+import '../utils/avatar_image.dart';
 
 class EditUserPage extends StatelessWidget {
   const EditUserPage({super.key});
@@ -36,9 +35,7 @@ class EditUserPage extends StatelessWidget {
           final roleText = user.roles.map((r) => r.name).join(', ');
           return ListTile(
             leading: CircleAvatar(
-              backgroundImage: user.photoUrl != null && user.photoUrl!.isNotEmpty
-                  ? FileImage(File(user.photoUrl!))
-                  : null,
+              backgroundImage: avatarImage(user.photoUrl),
               child: user.photoUrl == null || user.photoUrl!.isEmpty
                   ? const Icon(Icons.person)
                   : null,
@@ -89,9 +86,7 @@ class EditUserPage extends StatelessWidget {
                     },
                     child: CircleAvatar(
                       radius: 30,
-                      backgroundImage: photoUrl != null && photoUrl!.isNotEmpty
-                          ? FileImage(File(photoUrl!))
-                          : null,
+                      backgroundImage: avatarImage(photoUrl),
                       child: photoUrl == null || photoUrl!.isEmpty
                           ? const Icon(Icons.person)
                           : null,

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
@@ -10,6 +8,7 @@ import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../services/role_provider.dart';
+import '../utils/avatar_image.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -92,9 +91,7 @@ class _ProfilePageState extends State<ProfilePage> {
                         onTap: _pickImage,
                         child: CircleAvatar(
                           radius: 40,
-                          backgroundImage: _photoUrl != null && _photoUrl!.isNotEmpty
-                              ? FileImage(File(_photoUrl!))
-                              : null,
+                          backgroundImage: avatarImage(_photoUrl),
                           child: _photoUrl == null || _photoUrl!.isEmpty
                               ? const Icon(Icons.person, size: 40)
                               : null,

--- a/lib/screens/provider_selection_page.dart
+++ b/lib/screens/provider_selection_page.dart
@@ -1,11 +1,10 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 import 'edit_appointment_page.dart';
+import '../utils/avatar_image.dart';
 
 class ProviderSelectionPage extends StatelessWidget {
   final ServiceType serviceType;
@@ -31,10 +30,7 @@ class ProviderSelectionPage extends StatelessWidget {
                 final provider = providers[index];
                 return ListTile(
                   leading: CircleAvatar(
-                    backgroundImage: provider.photoUrl != null &&
-                            provider.photoUrl!.isNotEmpty
-                        ? FileImage(File(provider.photoUrl!))
-                        : null,
+                    backgroundImage: avatarImage(provider.photoUrl),
                     child: provider.photoUrl == null ||
                             provider.photoUrl!.isEmpty
                         ? const Icon(Icons.person)

--- a/lib/utils/avatar_image.dart
+++ b/lib/utils/avatar_image.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+
+import 'avatar_image_stub.dart'
+    if (dart.library.io) 'avatar_image_io.dart';
+
+/// Returns an [ImageProvider] for the given [path].
+///
+/// On mobile platforms a [FileImage] is used.
+/// On web, [NetworkImage] is used for URLs while base64-encoded data URLs
+/// are decoded into a [MemoryImage].
+ImageProvider? avatarImage(String? path) {
+  if (path == null || path.isEmpty) return null;
+
+  if (kIsWeb) {
+    if (path.startsWith('data:')) {
+      final base64Data = path.split(',').last;
+      return MemoryImage(base64Decode(base64Data));
+    }
+    return NetworkImage(path);
+  }
+  return fileImage(path);
+}

--- a/lib/utils/avatar_image_io.dart
+++ b/lib/utils/avatar_image_io.dart
@@ -1,0 +1,4 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+
+ImageProvider fileImage(String path) => FileImage(File(path));

--- a/lib/utils/avatar_image_stub.dart
+++ b/lib/utils/avatar_image_stub.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+ImageProvider fileImage(String path) =>
+    throw UnsupportedError('File images are not supported on this platform.');


### PR DESCRIPTION
## Summary
- add avatarImage helper selecting FileImage on mobile and Network/MemoryImage on web
- refactor avatar displays to use avatarImage and drop direct dart:io usage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc4679c1c832ba214d8c0f6fb6fd5