### PR TITLE
Add macOS privacy usage descriptions

### DIFF
--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -27,6 +27,12 @@
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+        <string>NSApplication</string>
+        <key>NSCameraUsageDescription</key>
+        <string>This app requires camera access to capture photos.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>This app requires photo library access to select images.</string>
+        <key>NSPhotoLibraryAddUsageDescription</key>
+        <string>This app requires permission to save images to your library.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add camera and photo library usage descriptions to macOS Info.plist

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bcc77b76c832babcfd93ade827c73