### PR TITLE
feat: support desktop image picking

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 import '../models/user_profile.dart';
@@ -9,6 +8,7 @@ import '../models/user_role.dart';
 import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
+import '../utils/image_picking.dart';
 
 class EditUserPage extends StatelessWidget {
   const EditUserPage({super.key});
@@ -64,7 +64,6 @@ class EditUserPage extends StatelessWidget {
     final nameController = TextEditingController(text: user?.name ?? '');
     final formKey = GlobalKey<FormState>();
     Uint8List? photoBytes = user?.photoBytes;
-    final picker = ImagePicker();
     final roles = <UserRole>{...user?.roles ?? {}};
     final selectedServices = <ServiceType>{...user?.services ?? {}};
 
@@ -81,10 +80,17 @@ class EditUserPage extends StatelessWidget {
                 children: [
                   GestureDetector(
                     onTap: () async {
-                      final picked =
-                          await picker.pickImage(source: ImageSource.gallery);
-                      if (picked != null) {
-                        final bytes = await picked.readAsBytes();
+                      if (!isImagePickerSupported) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text(
+                                'Image selection not supported on this platform'),
+                          ),
+                        );
+                        return;
+                      }
+                      final bytes = await pickImageBytes();
+                      if (bytes != null) {
                         setState(() => photoBytes = bytes);
                       }
                     },

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 import '../models/user_profile.dart';
@@ -10,6 +9,7 @@ import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../services/role_provider.dart';
+import '../utils/image_picking.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -21,7 +21,6 @@ class ProfilePage extends StatefulWidget {
 class _ProfilePageState extends State<ProfilePage> {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
-  final _picker = ImagePicker();
 
   Uint8List? _photoBytes;
   late String _userId;
@@ -49,10 +48,15 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> _pickImage() async {
-    final picked = await _picker.pickImage(source: ImageSource.gallery);
-    if (picked != null) {
-      final bytes = await picked.readAsBytes();
+    final bytes = await pickImageBytes();
+    if (bytes != null) {
       setState(() => _photoBytes = bytes);
+    } else if (!isImagePickerSupported && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Image selection not supported on this platform'),
+        ),
+      );
     }
   }
 

--- a/lib/utils/image_picking.dart
+++ b/lib/utils/image_picking.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/foundation.dart';
+import 'package:image_picker/image_picker.dart';
+
+// Returns whether image picking is supported on the current platform.
+bool get isImagePickerSupported =>
+    kIsWeb ||
+    const {
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+      TargetPlatform.linux,
+    }.contains(defaultTargetPlatform);
+
+/// Picks an image and returns its bytes, or null if the user cancels or
+/// the platform is unsupported.
+Future<Uint8List?> pickImageBytes() async {
+  if (!isImagePickerSupported) return null;
+
+  XFile? file;
+  if (kIsWeb ||
+      defaultTargetPlatform == TargetPlatform.android ||
+      defaultTargetPlatform == TargetPlatform.iOS) {
+    file = await ImagePicker().pickImage(source: ImageSource.gallery);
+  } else {
+    file = await openFile(
+      acceptedTypeGroups: [
+        XTypeGroup(
+          label: 'images',
+          extensions: ['jpg', 'jpeg', 'png', 'gif'],
+        ),
+      ],
+    );
+  }
+
+  return file?.readAsBytes();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   hive_flutter: ^1.1.0
   intl: ^0.20.2
   image_picker: ^1.0.4
+  file_selector: ^1.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add file_selector dependency and cross-platform image picking helper
- handle image selection gracefully on platforms without support

## Testing
- `dart format lib/screens/edit_user_page.dart lib/screens/profile_page.dart lib/utils/image_picking.dart pubspec.yaml` *(fails: command not found)*
- `flutter format lib/screens/edit_user_page.dart lib/screens/profile_page.dart lib/utils/image_picking.dart pubspec.yaml` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689be08135f0832b8c8aa0e86c294279