### PR TITLE
fix: ensure image picking uses Uint8List

### DIFF
--- a/lib/utils/image_picking.dart
+++ b/lib/utils/image_picking.dart
@@ -1,4 +1,6 @@
 
+import 'dart:typed_data';
+
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:image_picker/image_picker.dart';


### PR DESCRIPTION
## Summary
- import `dart:typed_data` for image picker util

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bfd68e4c4832bacdcbf0aa9abc042