### PR TITLE
Initialize Hive within AuthService

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -12,6 +12,7 @@ class AuthService extends ChangeNotifier {
   bool get isInitialized => _initialized;
 
   Future<void> init() async {
+    await Hive.initFlutter();
     _box = await Hive.openBox<Map<String, String>>(_boxName);
     _initialized = true;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -601,7 +601,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
   mockito: ^5.4.4
+  path_provider_platform_interface: ^2.1.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:vogue_vault/services/auth_service.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('registration and login succeed after init', () async {
+    final service = AuthService();
+    await service.init();
+
+    const email = 'test@example.com';
+    const password = 'secret';
+
+    await service.register(email, password);
+    expect(service.currentUser, email);
+
+    await service.logout();
+    final success = await service.login(email, password);
+    expect(success, isTrue);
+    expect(service.currentUser, email);
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure `AuthService.init` initializes Hive using `Hive.initFlutter`
- Add dev dependency for `path_provider_platform_interface`
- Add unit test to verify registration and login after service init

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bfeae43a4832b9e77709142599302