### PR TITLE
Handle removed selected role in RoleProvider

### DIFF
--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -18,6 +18,9 @@ class RoleProvider extends ChangeNotifier {
     _roles
       ..clear()
       ..addAll(roles);
+    if (_selectedRole != null && !_roles.contains(_selectedRole)) {
+      _selectedRole = null;
+    }
     notifyListeners();
   }
 

--- a/test/services/role_provider_test.dart
+++ b/test/services/role_provider_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:vogue_vault/services/role_provider.dart';
+import 'package:vogue_vault/models/user_role.dart';
+
+void main() {
+  test('selectedRole is cleared when its role is removed', () {
+    final provider = RoleProvider();
+    provider.selectedRole = UserRole.customer;
+
+    provider.setRoles({UserRole.professional});
+
+    expect(provider.selectedRole, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- clear `_selectedRole` if its role is absent after role list update
- test RoleProvider resets `selectedRole` when the role is removed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c003ecc0c832baeff58c390f44346