### PR TITLE
Handle legacy appointments without provider ID

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -30,10 +30,18 @@ class AppointmentService extends ChangeNotifier {
     }
   }
 
+  Map<String, dynamic> _withProviderId(Map<String, dynamic> map) {
+    return {
+      ...map,
+      'providerId': map['providerId'] ?? '',
+    };
+  }
+
   List<Appointment> get appointments {
     if (!_initialized) return [];
     return _appointmentsBox.values
-        .map((m) => Appointment.fromMap(Map<String, dynamic>.from(m)))
+        .map((m) => Appointment.fromMap(
+            _withProviderId(Map<String, dynamic>.from(m))))
         .toList();
   }
 
@@ -74,10 +82,7 @@ class AppointmentService extends ChangeNotifier {
     if (map == null) return null;
     final appointmentMap = Map<String, dynamic>.from(map);
     // Ensure providerId is available for older stored appointments.
-    return Appointment.fromMap({
-      ...appointmentMap,
-      'providerId': appointmentMap['providerId'] ?? '',
-    });
+    return Appointment.fromMap(_withProviderId(appointmentMap));
   }
 
   Future<void> addUser(UserProfile user) async {
@@ -96,7 +101,8 @@ class AppointmentService extends ChangeNotifier {
     _ensureInitialized();
 
     final affected = _appointmentsBox.values
-        .map(Appointment.fromMap)
+        .map((m) => Appointment.fromMap(
+            _withProviderId(Map<String, dynamic>.from(m))))
         .where((a) => a.clientId == id || a.providerId == id)
         .toList();
 

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/models/user_profile.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('legacy appointments load with default providerId', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    final box = Hive.box<Map<String, dynamic>>('appointments');
+    await box.put('a1', {
+      'id': 'a1',
+      'clientId': 'c1',
+      'service': ServiceType.hairCut.name,
+      'dateTime': DateTime.parse('2023-01-01').toIso8601String(),
+    });
+
+    final appts = service.appointments;
+    expect(appts, hasLength(1));
+    expect(appts.first.providerId, '');
+  });
+
+  test('deleteUser handles legacy appointments', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    final apptsBox = Hive.box<Map<String, dynamic>>('appointments');
+    final usersBox = Hive.box<Map<String, dynamic>>('users');
+
+    await usersBox.put('c1', UserProfile(id: 'c1', name: 'Client').toMap());
+
+    await apptsBox.put('a1', {
+      'id': 'a1',
+      'clientId': 'c1',
+      'service': ServiceType.hairCut.name,
+      'dateTime': DateTime.parse('2023-01-01').toIso8601String(),
+    });
+
+    await service.deleteUser('c1');
+
+    expect(apptsBox.isEmpty, isTrue);
+    expect(usersBox.get('c1'), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure providerId defaults to empty string when loading appointments
- add tests for loading and deleting legacy appointments without providerId

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c018b1b34832b87dbf4ed1f5bc15f