### PR TITLE
test: update service type enum reference

### DIFF
--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -38,7 +38,7 @@ void main() {
     await box.put('a1', {
       'id': 'a1',
       'clientId': 'c1',
-      'service': ServiceType.hairCut.name,
+      'service': ServiceType.hairdresser.name,
       'dateTime': DateTime.parse('2023-01-01').toIso8601String(),
     });
 
@@ -59,7 +59,7 @@ void main() {
     await apptsBox.put('a1', {
       'id': 'a1',
       'clientId': 'c1',
-      'service': ServiceType.hairCut.name,
+      'service': ServiceType.hairdresser.name,
       'dateTime': DateTime.parse('2023-01-01').toIso8601String(),
     });
 


### PR DESCRIPTION
## Summary
- fix appointment service tests to use `ServiceType.hairdresser`

## Testing
- `flutter test test/services/appointment_service_test.dart` *(fails: command not found)*
- `dart test test/services/appointment_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c04dcf4b8832ba9fc2f5f037cbd09