### PR TITLE
feat: prevent duplicate user registration

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -48,6 +48,9 @@ class AuthService extends ChangeNotifier {
   Future<void> register(String email, String password) async {
     _ensureInitialized();
     final users = _users;
+    if (users.containsKey(email)) {
+      throw StateError('User with email $email already exists.');
+    }
     users[email] = password;
     await _box.put(_usersKey, users);
     await _box.put(_currentUserKey, {'email': email});

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -43,4 +43,15 @@ void main() {
     expect(success, isTrue);
     expect(service.currentUser, email);
   });
+
+  test('duplicate registration is rejected', () async {
+    final service = AuthService();
+    await service.init();
+
+    const email = 'dup@example.com';
+    const password = 'password';
+
+    await service.register(email, password);
+    expect(service.register(email, password), throwsStateError);
+  });
 }


### PR DESCRIPTION
## Summary
- prevent duplicate user registration by checking existing emails
- add test for duplicate registration rejection

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c07e62a88832bbd6f3d2a6380966b