### PR TITLE
Initialize Hive once at startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
 import 'screens/auth_page.dart';
@@ -10,6 +11,8 @@ import 'services/role_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  await Hive.initFlutter();
 
   final appointmentService = AppointmentService();
   await appointmentService.init();

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -17,7 +17,6 @@ class AppointmentService extends ChangeNotifier {
   bool get isInitialized => _initialized;
 
   Future<void> init() async {
-    await Hive.initFlutter();
     _appointmentsBox =
         await Hive.openBox<Map<String, dynamic>>(_appointmentsBoxName);
     _usersBox = await Hive.openBox<Map<String, dynamic>>(_usersBoxName);

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -12,7 +12,6 @@ class AuthService extends ChangeNotifier {
   bool get isInitialized => _initialized;
 
   Future<void> init() async {
-    await Hive.initFlutter();
     _box = await Hive.openBox<Map<String, String>>(_boxName);
     _initialized = true;
   }

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -22,8 +22,9 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(() {
+  setUpAll(() async {
     PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
   });
 
   tearDown(() async {

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -20,8 +20,9 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(() {
+  setUpAll(() async {
     PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
   });
 
   tearDown(() async {


### PR DESCRIPTION
## Summary
- Initialize Hive once in `main.dart` before creating services
- Remove redundant Hive initialization from `AuthService` and `AppointmentService`
- Ensure tests initialize Hive during setup

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c09106368832bacb1f1143e2b470d