### PR TITLE
chore: upgrade upload-artifact action

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -16,7 +16,7 @@ jobs:
       - run: flutter pub get
       - run: flutter build apk --release
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-apk
           path: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
## Summary
- upgrade actions/upload-artifact from v3 to v4 in APK build workflow

## Testing
- `flutter test` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git -b stable --depth 1 /opt/flutter` *(fails: unable to access 'https://github.com/flutter/flutter.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c18f53368832b91a6ea2049f6c8f0