### PR TITLE
Add localization support and translate Appointments screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "en",
+  "appTitle": "Vogue Vault",
+  "appointmentsTitle": "Appointments",
+  "profileTooltip": "Profile",
+  "switchRoleTooltip": "Switch Role",
+  "usersTooltip": "Users",
+  "unknownUser": "Unknown"
+}

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "es",
+  "appTitle": "Bóveda de la Moda",
+  "appointmentsTitle": "Citas",
+  "profileTooltip": "Perfil",
+  "switchRoleTooltip": "Cambiar rol",
+  "usersTooltip": "Usuarios",
+  "unknownUser": "Desconocido"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
@@ -50,7 +52,7 @@ class MyApp extends StatelessWidget {
     );
 
     return MaterialApp(
-      title: 'Vogue Vault',
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: lightScheme,
@@ -75,6 +77,13 @@ class MyApp extends StatelessWidget {
           bodyMedium: TextStyle(fontSize: 16),
         ),
       ),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
       // Start the app with authentication.
       home: const AuthPage(),
     );

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../models/appointment.dart';
 import '../models/user_role.dart';
@@ -23,11 +24,11 @@ class AppointmentsPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Appointments'),
+        title: Text(AppLocalizations.of(context)!.appointmentsTitle),
         actions: [
           IconButton(
             icon: const Icon(Icons.account_circle),
-            tooltip: 'Profile',
+            tooltip: AppLocalizations.of(context)!.profileTooltip,
             onPressed: () {
               Navigator.push(
                 context,
@@ -39,7 +40,7 @@ class AppointmentsPage extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.switch_account),
-            tooltip: 'Switch Role',
+            tooltip: AppLocalizations.of(context)!.switchRoleTooltip,
             onPressed: () {
               context.read<RoleProvider>().clearRole();
               Navigator.pushAndRemoveUntil(
@@ -54,7 +55,7 @@ class AppointmentsPage extends StatelessWidget {
           if (role == UserRole.professional)
             IconButton(
               icon: const Icon(Icons.people),
-              tooltip: 'Users',
+              tooltip: AppLocalizations.of(context)!.usersTooltip,
               onPressed: () {
                 Navigator.push(
                   context,
@@ -80,7 +81,7 @@ class AppointmentsPage extends StatelessWidget {
               ),
             ),
             title: Text(
-              '${client?.name ?? 'Unknown'} - ${serviceTypeLabel(appt.service)}',
+              '${client?.name ?? AppLocalizations.of(context)!.unknownUser} - ${serviceTypeLabel(appt.service)}',
             ),
             subtitle: Text(
               DateFormat.yMMMd().add_jm().format(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -60,6 +62,7 @@ dev_dependencies:
 # The following section is specific to Flutter packages.
 flutter:
 
+  generate: true
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## Summary
- integrate `flutter_localizations` and enable l10n code generation
- add English and Spanish ARB files with common UI strings
- localize `AppointmentsPage` and wire up delegates in `MaterialApp`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c76396d68832b82de157561cac082