### PR TITLE
Ensure appointment edit form scrolls above keyboard

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -100,8 +100,14 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
             ? AppLocalizations.of(context)!.editAppointmentTitle
             : AppLocalizations.of(context)!.newAppointmentTitle),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
+      resizeToAvoidBottomInset: true,
+      body: SingleChildScrollView(
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: 16,
+          bottom: 16 + MediaQuery.of(context).viewInsets.bottom,
+        ),
         child: Form(
           key: _formKey,
           child: Column(


### PR DESCRIPTION
## Summary
- Wrap appointment form in `SingleChildScrollView` to avoid keyboard overlap
- Preserve padding and allow scrolling by using dynamic bottom inset

## Testing
- ⚠️ `flutter test` *(missing: flutter command)*

------
https://chatgpt.com/codex/tasks/task_e_689c7b0fe638832b95790b1fb41db2d3