### PR TITLE
Show empty state for appointments

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -50,5 +50,7 @@
   "loginButton": "Login",
   "registerButton": "Register",
   "createAccount": "Create an account",
-  "haveAccountSignIn": "Have an account? Sign in"
+  "haveAccountSignIn": "Have an account? Sign in",
+  "noAppointmentsScheduled": "No appointments scheduled.",
+  "addFirstAppointment": "Add your first appointment"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -50,5 +50,7 @@
   "loginButton": "Ingresar",
   "registerButton": "Registrarse",
   "createAccount": "Crear una cuenta",
-  "haveAccountSignIn": "¿Tienes una cuenta? Inicia sesión"
+  "haveAccountSignIn": "¿Tienes una cuenta? Inicia sesión",
+  "noAppointmentsScheduled": "No hay citas programadas.",
+  "addFirstAppointment": "Agrega tu primera cita"
 }

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -67,46 +67,71 @@ class AppointmentsPage extends StatelessWidget {
             ),
         ],
       ),
-      body: ListView.builder(
-        itemCount: appointments.length,
-        itemBuilder: (context, index) {
-          final Appointment appt = appointments[index];
-          final client = service.getUser(appt.clientId);
-          return ListTile(
-            leading: CircleAvatar(
-              backgroundColor: serviceTypeColor(appt.service),
-              child: Icon(
-                serviceTypeIcon(appt.service),
-                color: Colors.white,
-              ),
-            ),
-            title: Text(
-              '${client?.name ?? AppLocalizations.of(context)!.unknownUser} - ${serviceTypeLabel(appt.service)}',
-            ),
-            subtitle: Text(
-              DateFormat.yMMMd().add_jm().format(
-                    appt.dateTime.toLocal(),
-                  ),
-            ),
-            onTap: role == UserRole.professional
-                ? () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => EditAppointmentPage(appointment: appt),
+      body: appointments.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(AppLocalizations.of(context)!.noAppointmentsScheduled),
+                  if (role == UserRole.professional) ...[
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => const EditAppointmentPage(),
+                          ),
+                        );
+                      },
+                      child: Text(
+                        AppLocalizations.of(context)!.addFirstAppointment,
                       ),
-                    );
-                  }
-                : null,
-            trailing: role == UserRole.professional
-                ? IconButton(
-                    icon: const Icon(Icons.delete),
-                    onPressed: () => service.deleteAppointment(appt.id),
-                  )
-                : null,
-          );
-        },
-      ),
+                    ),
+                  ],
+                ],
+              ),
+            )
+          : ListView.builder(
+              itemCount: appointments.length,
+              itemBuilder: (context, index) {
+                final Appointment appt = appointments[index];
+                final client = service.getUser(appt.clientId);
+                return ListTile(
+                  leading: CircleAvatar(
+                    backgroundColor: serviceTypeColor(appt.service),
+                    child: Icon(
+                      serviceTypeIcon(appt.service),
+                      color: Colors.white,
+                    ),
+                  ),
+                  title: Text(
+                    '${client?.name ?? AppLocalizations.of(context)!.unknownUser} - ${serviceTypeLabel(appt.service)}',
+                  ),
+                  subtitle: Text(
+                    DateFormat.yMMMd().add_jm().format(
+                          appt.dateTime.toLocal(),
+                        ),
+                  ),
+                  onTap: role == UserRole.professional
+                      ? () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => EditAppointmentPage(appointment: appt),
+                            ),
+                          );
+                        }
+                      : null,
+                  trailing: role == UserRole.professional
+                      ? IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => service.deleteAppointment(appt.id),
+                        )
+                      : null,
+                );
+              },
+            ),
       floatingActionButton: role == UserRole.professional
           ? FloatingActionButton(
               onPressed: () {


### PR DESCRIPTION
## Summary
- display message when no appointments are scheduled
- add localized strings for empty appointments and add-first button

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c800de568832bb8de71a466fefb6e