### PR TITLE
feat: add accessible avatar semantics

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6,6 +6,7 @@
   "switchRoleTooltip": "Switch Role",
   "usersTooltip": "Users",
   "unknownUser": "Unknown",
+  "userPhotoLabel": "User photo",
   "profileTitle": "Profile",
   "imageSelectionUnsupported": "Image selection not supported on this platform",
   "nameLabel": "Name",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -6,6 +6,7 @@
   "switchRoleTooltip": "Cambiar rol",
   "usersTooltip": "Usuarios",
   "unknownUser": "Desconocido",
+  "userPhotoLabel": "Foto del usuario",
   "profileTitle": "Perfil",
   "imageSelectionUnsupported": "La selección de imágenes no es compatible con esta plataforma",
   "nameLabel": "Nombre",

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -79,6 +79,13 @@ class _ProfilePageState extends State<ProfilePage> {
     }
   }
 
+  String get _initials {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return '?';
+    final parts = name.split(RegExp(r'\s+'));
+    return parts.map((p) => p[0]).take(2).join().toUpperCase();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -98,14 +105,19 @@ class _ProfilePageState extends State<ProfilePage> {
                     children: [
                       GestureDetector(
                         onTap: _pickImage,
-                        child: CircleAvatar(
-                          radius: 40,
-                          backgroundImage: _photoBytes != null
-                              ? MemoryImage(_photoBytes!)
-                              : null,
-                          child: _photoBytes == null || _photoBytes!.isEmpty
-                              ? const Icon(Icons.person, size: 40)
-                              : null,
+                        child: Semantics(
+                          label:
+                              AppLocalizations.of(context)!.userPhotoLabel,
+                          image: true,
+                          child: CircleAvatar(
+                            radius: 40,
+                            backgroundImage: _photoBytes != null
+                                ? MemoryImage(_photoBytes!)
+                                : null,
+                            child: _photoBytes == null || _photoBytes!.isEmpty
+                                ? Text(_initials)
+                                : null,
+                          ),
                         ),
                       ),
                       const SizedBox(height: 16),
@@ -115,6 +127,7 @@ class _ProfilePageState extends State<ProfilePage> {
                         controller: _nameController,
                         decoration: InputDecoration(
                             labelText: AppLocalizations.of(context)!.nameLabel),
+                        onChanged: (_) => setState(() {}),
                         validator: (value) => value == null || value.trim().isEmpty
                             ? AppLocalizations.of(context)!.nameRequired
                             : null,

--- a/lib/screens/provider_selection_page.dart
+++ b/lib/screens/provider_selection_page.dart
@@ -29,15 +29,28 @@ class ProviderSelectionPage extends StatelessWidget {
               itemCount: providers.length,
               itemBuilder: (context, index) {
                 final provider = providers[index];
+                final initials = provider.name.trim().isNotEmpty
+                    ? provider.name
+                        .trim()
+                        .split(RegExp(r'\s+'))
+                        .map((p) => p[0])
+                        .take(2)
+                        .join()
+                        .toUpperCase()
+                    : '?';
                 return ListTile(
-                  leading: CircleAvatar(
-                    backgroundImage: provider.photoBytes != null
-                        ? MemoryImage(provider.photoBytes!)
-                        : null,
-                    child: provider.photoBytes == null ||
-                            provider.photoBytes!.isEmpty
-                        ? const Icon(Icons.person)
-                        : null,
+                  leading: Semantics(
+                    label: AppLocalizations.of(context)!.userPhotoLabel,
+                    image: true,
+                    child: CircleAvatar(
+                      backgroundImage: provider.photoBytes != null
+                          ? MemoryImage(provider.photoBytes!)
+                          : null,
+                      child: provider.photoBytes == null ||
+                              provider.photoBytes!.isEmpty
+                          ? Text(initials)
+                          : null,
+                    ),
                   ),
                   title: Text(provider.name),
                   onTap: () {


### PR DESCRIPTION
## Summary
- add localized `User photo` label and show initials when profile or provider has no image
- expose `Semantics` around avatars for better screen reader support

## Testing
- `dart format lib/screens/profile_page.dart lib/screens/provider_selection_page.dart` (fails: command not found)
- `flutter test` (fails: command not found)
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_689c84642bf4832ba44f18779b7d8517