### PR TITLE
chore: adjust Dart SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
+  # Dart SDK constraint aligned with project Flutter version
   sdk: ">=3.3.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.


### PR DESCRIPTION
## Summary
- add comment and confirm Dart SDK constraint range

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c92ffbccc832b8f71374e0699c5a2