### PR TITLE
chore: fix localization import path

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/appointment.dart';
 import '../models/user_role.dart';

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../services/auth_service.dart';
 import 'role_selection_page.dart';

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/appointment.dart';
 import '../models/service_type.dart';

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_profile.dart';
 import '../models/user_role.dart';

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_profile.dart';
 import '../models/user_role.dart';

--- a/lib/screens/provider_selection_page.dart
+++ b/lib/screens/provider_selection_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/service_type.dart';
 import '../services/appointment_service.dart';

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_role.dart';
 import '../services/auth_service.dart';

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/service_type.dart';
 import '../utils/service_type_utils.dart';


### PR DESCRIPTION
## Summary
- update localization imports to point at `lib/l10n/app_localizations.dart`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca09b9368832ba3516459fe933451