### PR TITLE
Remove const from early-return Center widgets

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -75,7 +75,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ? AppLocalizations.of(context)!.editAppointmentTitle
               : AppLocalizations.of(context)!.newAppointmentTitle),
         ),
-        body: const Center(
+        body: Center(
           child: Text(AppLocalizations.of(context)!.noClientsAvailable),
         ),
       );
@@ -88,7 +88,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ? AppLocalizations.of(context)!.editAppointmentTitle
               : AppLocalizations.of(context)!.newAppointmentTitle),
         ),
-        body: const Center(
+        body: Center(
           child: Text(AppLocalizations.of(context)!.noProvidersAvailableAdd),
         ),
       );


### PR DESCRIPTION
## Summary
- Allow localized strings to be evaluated at runtime by removing `const` from early-return `Center` widgets in `EditAppointmentPage`.

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ca1879128832b84797ac203e9a5d2