### PR TITLE
chore: downgrade flutter_lints for Dart 3.3

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,10 +330,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "4.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -561,10 +561,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: 976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "4.0.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0
   mockito: ^5.4.4
   path_provider_platform_interface: ^2.1.2
 


### PR DESCRIPTION
## Summary
- use flutter_lints 4.x compatible with Dart 3.3
- update lockfile for flutter_lints and lints

## Testing
- `flutter pub get` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4115b40832b8dab13cbd6b7ff47