### PR TITLE
chore: pin flutter_gen to 5.10.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,18 +314,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_gen
-      sha256: "102471a3c6ee7d9175ac8f1989e1bd0e1b4f0d23615da4f961cf9e82752550fe"
+      sha256: "4117a3ea6b26a910c715bd58abcc5a90447e70930a5b98249e94c41da9e849bb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.10.0"
   flutter_gen_core:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: eda54fdc5de08e7eeea663eb8442aafc8660b5a13fda4e0c9e572c64e50195fb
+      sha256: "3eaa2d3d8be58267ac4cd5e215ac965dd23cae0410dc073de2e82e227be32bfc"
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.10.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   image_picker: ^1.0.4
   file_selector: ^1.0.3
   crypto: ^3.0.3
-  flutter_gen: ^5.11.0
+  flutter_gen: ^5.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- downgrade flutter_gen dependency to 5.10.0
- update lockfile to match

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca69b0d28832b90eb3cb61f53e221