### PR TITLE
Pin intl dependency to 0.18.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -513,10 +513,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   provider: ^6.0.5
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  intl: ^0.20.2
+  intl: 0.18.1
   image_picker: ^1.0.4
   file_selector: ^1.0.3
   crypto: ^3.0.3


### PR DESCRIPTION
## Summary
- pin intl to 0.18.1

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cac7728ac832b8a792d829ecf062a