### PR TITLE
chore: downgrade flutter_gen dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,18 +314,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_gen
-      sha256: "4117a3ea6b26a910c715bd58abcc5a90447e70930a5b98249e94c41da9e849bb"
+      sha256: "a727fbe4d9443ac05258ef7a987650f8d8f16b4f8c22cf98c1ac9183ac7f3eff"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.9.0"
   flutter_gen_core:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: "3eaa2d3d8be58267ac4cd5e215ac965dd23cae0410dc073de2e82e227be32bfc"
+      sha256: "53890b653738f34363d9f0d40f82104c261716bd551d3ba65f648770b6764c21"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.9.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   image_picker: ^1.0.4
   file_selector: ^1.0.3
   crypto: ^3.0.3
-  flutter_gen: ^5.10.0
+  flutter_gen: ^5.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- downgrade flutter_gen to 5.9.0

## Testing
- `flutter pub get` (failed: Because vogue_vault depends on intl 0.18.1, version solving failed)
- `flutter test` (failed: Because vogue_vault depends on intl 0.18.1, version solving failed)


------
https://chatgpt.com/codex/tasks/task_e_689cbb737568832bafdb6880344a9387