### PR TITLE
ci: modernize APK workflow and restore pubspec

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -2,17 +2,17 @@ name: Build APK
 
 on:
   push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.19.0'
+          channel: stable
+          cache: true
       - run: flutter pub get
       - run: flutter build apk --release
       - name: Upload APK


### PR DESCRIPTION
## Summary
- revert previous changes to `pubspec.yaml` and lockfile to restore latest dependency versions
- update build workflow to run on every push and use the latest stable Flutter with caching

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ca69b0d28832b90eb3cb61f53e221