### PR TITLE
Add typed data import to image picker utility

### DIFF
--- a/lib/utils/image_picking.dart
+++ b/lib/utils/image_picking.dart
@@ -1,4 +1,4 @@
-
+import 'dart:typed_data';
 
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
## Summary
- import `dart:typed_data` to support `Uint8List` in image picking utility

## Testing
- `dart analyze lib/utils/image_picking.dart` *(fails: command not found)*
- `flutter analyze lib/utils/image_picking.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d0057c4cc832badb281d698bb14cc