### PR TITLE
Clear selected role when removed

### DIFF
--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -31,6 +31,9 @@ class RoleProvider extends ChangeNotifier {
 
   void removeRole(UserRole role) {
     _roles.remove(role);
+    if (_selectedRole == role) {
+      _selectedRole = null;
+    }
     notifyListeners();
   }
 

--- a/test/services/role_provider_test.dart
+++ b/test/services/role_provider_test.dart
@@ -12,4 +12,13 @@ void main() {
 
     expect(provider.selectedRole, isNull);
   });
+
+  test('selectedRole is cleared when removing selected role', () {
+    final provider = RoleProvider();
+    provider.selectedRole = UserRole.customer;
+
+    provider.removeRole(UserRole.customer);
+
+    expect(provider.selectedRole, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- Clear `_selectedRole` when the role is removed
- Add regression test ensuring removing the current role clears selection

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d05f737d0832bbcdbfc29b1851b31