### PR TITLE
Await service calls when saving appointment

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -205,7 +205,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ),
               const SizedBox(height: 24),
               ElevatedButton(
-                onPressed: () {
+                onPressed: () async {
                   if (!_formKey.currentState!.validate()) return;
                   final id = widget.appointment?.id ??
                       DateTime.now().millisecondsSinceEpoch.toString();
@@ -217,10 +217,11 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                     dateTime: _dateTime,
                   );
                   if (isEditing) {
-                    service.updateAppointment(newAppt);
+                    await service.updateAppointment(newAppt);
                   } else {
-                    service.addAppointment(newAppt);
+                    await service.addAppointment(newAppt);
                   }
+                  if (!mounted) return;
                   Navigator.pop(context);
                 },
                 child: Text(AppLocalizations.of(context)!.saveButton),


### PR DESCRIPTION
## Summary
- make save button handler async and await appointment service operations

## Testing
- `dart analyze lib/screens/edit_appointment_page.dart` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*

------
https://chatgpt.com/codex/tasks/task_e_689d09d08034832baa14a48caaa9b42d