### PR TITLE
Use localized serviceType labels in appointment editor

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -5,6 +5,7 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 import '../models/appointment.dart';
 import '../models/service_type.dart';
 import '../services/appointment_service.dart';
+import '../utils/service_type_utils.dart';
 
 class EditAppointmentPage extends StatefulWidget {
   final Appointment? appointment;
@@ -136,7 +137,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                     .map(
                       (s) => DropdownMenuItem<ServiceType>(
                         value: s,
-                        child: Text(s.name),
+                        child: Text(serviceTypeLabel(s)),
                       ),
                     )
                     .toList(),


### PR DESCRIPTION
## Summary
- display service type labels using `serviceTypeLabel` instead of enum names
- import `service_type_utils.dart` so service labels are human-friendly

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689d0cf60910832baedd61c9bbd13c3d