### PR TITLE
Allow scheduling appointments for guest clients

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -53,5 +53,8 @@
   "createAccount": "Create an account",
   "haveAccountSignIn": "Have an account? Sign in",
   "noAppointmentsScheduled": "No appointments scheduled.",
-  "addFirstAppointment": "Add your first appointment"
+  "addFirstAppointment": "Add your first appointment",
+  "guestNameLabel": "Guest Name",
+  "guestContactLabel": "Guest Contact (optional)",
+  "clientOrGuestValidation": "Please select a client or enter a guest name"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -53,5 +53,8 @@
   "createAccount": "Crear una cuenta",
   "haveAccountSignIn": "¿Tienes una cuenta? Inicia sesión",
   "noAppointmentsScheduled": "No hay citas programadas.",
-  "addFirstAppointment": "Agrega tu primera cita"
+  "addFirstAppointment": "Agrega tu primera cita",
+  "guestNameLabel": "Nombre del invitado",
+  "guestContactLabel": "Contacto del invitado (opcional)",
+  "clientOrGuestValidation": "Selecciona un cliente o ingresa un nombre de invitado"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -418,6 +418,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add your first appointment'**
   String get addFirstAppointment;
+
+  /// No description provided for @guestNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Guest Name'**
+  String get guestNameLabel;
+
+  /// No description provided for @guestContactLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Guest Contact (optional)'**
+  String get guestContactLabel;
+
+  /// No description provided for @clientOrGuestValidation.
+  ///
+  /// In en, this message translates to:
+  /// **'Please select a client or enter a guest name'**
+  String get clientOrGuestValidation;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -169,4 +169,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get addFirstAppointment => 'Add your first appointment';
+
+  @override
+  String get guestNameLabel => 'Guest Name';
+
+  @override
+  String get guestContactLabel => 'Guest Contact (optional)';
+
+  @override
+  String get clientOrGuestValidation =>
+      'Please select a client or enter a guest name';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -169,4 +169,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get addFirstAppointment => 'Agrega tu primera cita';
+
+  @override
+  String get guestNameLabel => 'Nombre del invitado';
+
+  @override
+  String get guestContactLabel => 'Contacto del invitado (opcional)';
+
+  @override
+  String get clientOrGuestValidation =>
+      'Selecciona un cliente o ingresa un nombre de invitado';
 }

--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -5,8 +5,15 @@ class Appointment {
   /// Unique identifier for the appointment.
   final String id;
 
-  /// Identifier of the user acting as the client.
-  final String clientId;
+  /// Identifier of the user acting as the client.  If `null`, this appointment
+  /// represents a guest who does not have an account in the system.
+  final String? clientId;
+
+  /// Display name for a guest client when [clientId] is `null`.
+  final String? guestName;
+
+  /// Optional contact information for a guest client.
+  final String? guestContact;
 
   /// Identifier of the user acting as the service provider.
   final String providerId;
@@ -20,7 +27,9 @@ class Appointment {
   /// Creates a new [Appointment].
   Appointment({
     required this.id,
-    required this.clientId,
+    this.clientId,
+    this.guestName,
+    this.guestContact,
     required this.providerId,
     required this.service,
     required this.dateTime,
@@ -30,6 +39,8 @@ class Appointment {
   Appointment copyWith({
     String? id,
     String? clientId,
+    String? guestName,
+    String? guestContact,
     String? providerId,
     ServiceType? service,
     DateTime? dateTime,
@@ -37,6 +48,8 @@ class Appointment {
     return Appointment(
       id: id ?? this.id,
       clientId: clientId ?? this.clientId,
+      guestName: guestName ?? this.guestName,
+      guestContact: guestContact ?? this.guestContact,
       providerId: providerId ?? this.providerId,
       service: service ?? this.service,
       dateTime: dateTime ?? this.dateTime,
@@ -47,7 +60,9 @@ class Appointment {
   factory Appointment.fromMap(Map<String, dynamic> map) {
     return Appointment(
       id: map['id'] as String,
-      clientId: map['clientId'] as String,
+      clientId: map['clientId'] as String?,
+      guestName: map['guestName'] as String?,
+      guestContact: map['guestContact'] as String?,
       providerId: map['providerId'] as String,
       service: ServiceType.values.byName(map['service'] as String),
       dateTime: DateTime.parse(map['dateTime'] as String),
@@ -59,6 +74,8 @@ class Appointment {
     return {
       'id': id,
       'clientId': clientId,
+      'guestName': guestName,
+      'guestContact': guestContact,
       'providerId': providerId,
       'service': service.name,
       'dateTime': dateTime.toIso8601String(),
@@ -72,6 +89,8 @@ class Appointment {
           runtimeType == other.runtimeType &&
           id == other.id &&
           clientId == other.clientId &&
+          guestName == other.guestName &&
+          guestContact == other.guestContact &&
           providerId == other.providerId &&
           service == other.service &&
           dateTime == other.dateTime;
@@ -79,6 +98,8 @@ class Appointment {
   @override
   int get hashCode => id.hashCode ^
       clientId.hashCode ^
+      guestName.hashCode ^
+      guestContact.hashCode ^
       providerId.hashCode ^
       service.hashCode ^
       dateTime.hashCode;

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -90,7 +90,11 @@ class AppointmentsPage extends StatelessWidget {
               itemCount: appointments.length,
               itemBuilder: (context, index) {
                 final Appointment appt = appointments[index];
-                final client = service.getUser(appt.clientId);
+                final clientName = appt.clientId != null
+                    ? service.getUser(appt.clientId!)?.name ??
+                        AppLocalizations.of(context)!.unknownUser
+                    : appt.guestName ??
+                        AppLocalizations.of(context)!.unknownUser;
                 return ListTile(
                   leading: CircleAvatar(
                     backgroundColor: serviceTypeColor(appt.service),
@@ -100,7 +104,7 @@ class AppointmentsPage extends StatelessWidget {
                     ),
                   ),
                   title: Text(
-                    '${client?.name ?? AppLocalizations.of(context)!.unknownUser} - ${serviceTypeLabel(appt.service)}',
+                    '$clientName - ${serviceTypeLabel(appt.service)}',
                   ),
                   subtitle: Text(
                     DateFormat.yMMMd().add_jm().format(appt.dateTime.toLocal()),

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -25,6 +25,8 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   DateTime _dateTime = DateTime.now();
   String? _selectedClientId;
   String? _selectedProviderId;
+  late final TextEditingController _guestNameController;
+  late final TextEditingController _guestContactController;
 
   @override
   void initState() {
@@ -34,6 +36,17 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
     _dateTime = widget.appointment?.dateTime ?? DateTime.now();
     _selectedClientId = widget.appointment?.clientId;
     _selectedProviderId = widget.appointment?.providerId ?? widget.initialProviderId;
+    _guestNameController =
+        TextEditingController(text: widget.appointment?.guestName ?? '');
+    _guestContactController =
+        TextEditingController(text: widget.appointment?.guestContact ?? '');
+  }
+
+  @override
+  void dispose() {
+    _guestNameController.dispose();
+    _guestContactController.dispose();
+    super.dispose();
   }
 
   @override
@@ -69,19 +82,6 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
     }
     final isEditing = widget.appointment != null;
 
-    if (clients.isEmpty) {
-      return Scaffold(
-        appBar: AppBar(
-          title: Text(isEditing
-              ? AppLocalizations.of(context)!.editAppointmentTitle
-              : AppLocalizations.of(context)!.newAppointmentTitle),
-        ),
-        body: Center(
-          child: Text(AppLocalizations.of(context)!.noClientsAvailable),
-        ),
-      );
-    }
-
     if (providers.isEmpty) {
       return Scaffold(
         appBar: AppBar(
@@ -113,21 +113,47 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
           key: _formKey,
           child: Column(
             children: [
-              DropdownButtonFormField<String>(
-                value: _selectedClientId,
-                hint: Text(AppLocalizations.of(context)!.selectClientHint),
-                items: clients
-                    .map(
-                      (c) => DropdownMenuItem<String>(
-                        value: c.id,
-                        child: Text(c.name),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (value) => setState(() => _selectedClientId = value),
-                validator: (value) => value == null
-                    ? AppLocalizations.of(context)!.selectClientValidation
-                    : null,
+              if (clients.isNotEmpty)
+                DropdownButtonFormField<String>(
+                  value: _selectedClientId,
+                  hint: Text(AppLocalizations.of(context)!.selectClientHint),
+                  items: clients
+                      .map(
+                        (c) => DropdownMenuItem<String>(
+                          value: c.id,
+                          child: Text(c.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) => setState(() => _selectedClientId = value),
+                  validator: (_) {
+                    if ((_selectedClientId == null || _selectedClientId!.isEmpty) &&
+                        _guestNameController.text.isEmpty) {
+                      return AppLocalizations.of(context)!
+                          .clientOrGuestValidation;
+                    }
+                    return null;
+                  },
+                ),
+              TextFormField(
+                controller: _guestNameController,
+                decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context)!.guestNameLabel,
+                ),
+                validator: (value) {
+                  if ((_selectedClientId == null || _selectedClientId!.isEmpty) &&
+                      (value == null || value.isEmpty)) {
+                    return AppLocalizations.of(context)!
+                        .clientOrGuestValidation;
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _guestContactController,
+                decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context)!.guestContactLabel,
+                ),
               ),
               DropdownButtonFormField<ServiceType>(
                 value: _service,
@@ -212,7 +238,15 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                       DateTime.now().millisecondsSinceEpoch.toString();
                   final newAppt = Appointment(
                     id: id,
-                    clientId: _selectedClientId!,
+                    clientId: _selectedClientId,
+                    guestName:
+                        _selectedClientId == null || _selectedClientId!.isEmpty
+                            ? _guestNameController.text
+                            : null,
+                    guestContact:
+                        _selectedClientId == null || _selectedClientId!.isEmpty
+                            ? _guestContactController.text
+                            : null,
                     providerId: _selectedProviderId!,
                     service: _service,
                     dateTime: _dateTime,

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -22,6 +22,23 @@ void main() {
       expect(from.dateTime, appointment.dateTime);
     });
 
+    test('supports guest clients', () {
+      final appointment = Appointment(
+        id: 'a2',
+        guestName: 'Walk-in',
+        guestContact: '555-1234',
+        providerId: 'p1',
+        service: ServiceType.barber,
+        dateTime: DateTime(2023, 9, 10, 11, 0),
+      );
+      final map = appointment.toMap();
+      final from = Appointment.fromMap(map);
+
+      expect(from.clientId, isNull);
+      expect(from.guestName, appointment.guestName);
+      expect(from.guestContact, appointment.guestContact);
+    });
+
     test('fromMap validates required data', () {
       final missingFields = {'id': 'a1'};
       expect(() => Appointment.fromMap(missingFields), throwsA(isA<TypeError>()));
@@ -54,6 +71,28 @@ void main() {
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
 
+      expect(a1, equals(a2));
+      expect(a1.hashCode, equals(a2.hashCode));
+    });
+
+    test('appointments with same guest values are equal', () {
+      final dt = DateTime(2023, 9, 10, 10, 0);
+      final a1 = Appointment(
+        id: 'a1',
+        guestName: 'Walk-in',
+        guestContact: '555',
+        providerId: 'p1',
+        service: ServiceType.barber,
+        dateTime: dt,
+      );
+      final a2 = Appointment(
+        id: 'a1',
+        guestName: 'Walk-in',
+        guestContact: '555',
+        providerId: 'p1',
+        service: ServiceType.barber,
+        dateTime: dt,
+      );
       expect(a1, equals(a2));
       expect(a1.hashCode, equals(a2.hashCode));
     });

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -6,6 +6,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import 'package:vogue_vault/services/appointment_service.dart';
 import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/models/appointment.dart';
 import 'package:vogue_vault/models/user_profile.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
@@ -68,5 +69,22 @@ void main() {
 
     expect(apptsBox.isEmpty, isTrue);
     expect(usersBox.get('c1'), isNull);
+  });
+
+  test('addAppointment supports guest clients', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    final appt = Appointment(
+      id: 'a2',
+      guestName: 'Walk-in',
+      providerId: 'p1',
+      service: ServiceType.barber,
+      dateTime: DateTime.parse('2023-01-01'),
+    );
+    await service.addAppointment(appt);
+    final stored = service.getAppointment('a2');
+    expect(stored?.guestName, 'Walk-in');
+    expect(stored?.clientId, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- Support guest client details in `Appointment` model and persistence
- Update appointment editor and list to handle guest names and contacts
- Add localization and tests for guest appointments

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d0f9d6d7c832b9fd6149e99be6109