### PR TITLE
Handle dynamic maps from Hive in AuthService

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -25,8 +25,11 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  Map<String, String> get _users =>
-      _box.get(_usersKey) ?? <String, String>{};
+  Map<String, String> get _users {
+    final raw = _box.get(_usersKey);
+    if (raw == null) return <String, String>{};
+    return Map<String, String>.from(raw);
+  }
 
   String? get currentUser {
     _ensureInitialized();


### PR DESCRIPTION
## Summary
- Safely cast Hive-stored user map to `Map<String, String>` to avoid runtime type errors.

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d3eb6312c832ba10dbbd71586ec0a