### PR TITLE
Avoid typed Hive boxes to prevent map cast errors

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -10,16 +10,18 @@ class AppointmentService extends ChangeNotifier {
   static const _appointmentsBoxName = 'appointments';
   static const _usersBoxName = 'users';
 
-  late Box<Map<String, dynamic>> _appointmentsBox;
-  late Box<Map<String, dynamic>> _usersBox;
+  /// Underlying storage boxes. Hive may return values as
+  /// `Map<dynamic, dynamic>` regardless of the generics provided. Using
+  /// untyped boxes prevents runtime cast errors when retrieving stored maps.
+  late Box _appointmentsBox;
+  late Box _usersBox;
 
   bool _initialized = false;
   bool get isInitialized => _initialized;
 
   Future<void> init() async {
-    _appointmentsBox =
-        await Hive.openBox<Map<String, dynamic>>(_appointmentsBoxName);
-    _usersBox = await Hive.openBox<Map<String, dynamic>>(_usersBoxName);
+    _appointmentsBox = await Hive.openBox(_appointmentsBoxName);
+    _usersBox = await Hive.openBox(_usersBoxName);
     _initialized = true;
   }
 

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -36,7 +36,7 @@ void main() {
     final service = AppointmentService();
     await service.init();
 
-    final box = Hive.box<Map<String, dynamic>>('appointments');
+    final box = Hive.box('appointments');
     await box.put('a1', {
       'id': 'a1',
       'clientId': 'c1',
@@ -53,8 +53,8 @@ void main() {
     final service = AppointmentService();
     await service.init();
 
-    final apptsBox = Hive.box<Map<String, dynamic>>('appointments');
-    final usersBox = Hive.box<Map<String, dynamic>>('users');
+    final apptsBox = Hive.box('appointments');
+    final usersBox = Hive.box('users');
 
     await usersBox.put('c1', UserProfile(id: 'c1', name: 'Client').toMap());
 

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     await service.register(email, password);
 
-    final box = Hive.box<Map<String, String>>('auth');
+    final box = Hive.box('auth');
     final stored = box.get('users')![email]!;
     final expected = sha256.convert(utf8.encode(password)).toString();
     expect(stored, expected);
@@ -71,7 +71,7 @@ void main() {
     const password = 'pass123';
     final hashed = sha256.convert(utf8.encode(password)).toString();
 
-    final box = Hive.box<Map<String, String>>('auth');
+    final box = Hive.box('auth');
     await box.put('users', {email: hashed});
 
     final success = await service.login(email, password);


### PR DESCRIPTION
## Summary
- Use untyped Hive boxes in `AppointmentService` to avoid runtime `Map<String,dynamic>` cast issues
- Adjust tests to work with untyped boxes

## Testing
- `dart format lib/services/appointment_service.dart test/services/appointment_service_test.dart test/services/auth_service_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d46f95718832b91ded8f2b91521e8