### PR TITLE
Avoid typed Hive boxes to prevent map cast errors

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -72,147 +72,153 @@ class EditUserPage extends StatelessWidget {
     final roles = <UserRole>{...user?.roles ?? {}};
     final selectedServices = <ServiceType>{...user?.services ?? {}};
 
-    await showDialog(
-      context: context,
-      builder: (_) => StatefulBuilder(
-        builder: (context, setState) {
-          return AlertDialog(
-            title: Text(user == null
-                ? AppLocalizations.of(context)!.newUserTitle
-                : AppLocalizations.of(context)!.editUserTitle),
-            content: Form(
-              key: formKey,
-              child: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    GestureDetector(
-                      onTap: () async {
-                        if (!isImagePickerSupported) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(
-                                  AppLocalizations.of(context)!
-                                      .imageSelectionUnsupported),
-                            ),
-                          );
-                          return;
-                        }
-                        final bytes = await pickImageBytes();
-                        if (bytes != null) {
-                          setState(() => photoBytes = bytes);
-                        }
-                      },
-                      child: CircleAvatar(
-                        radius: 30,
-                        backgroundImage: photoBytes != null
-                            ? MemoryImage(photoBytes!)
-                            : null,
-                        child: photoBytes == null || photoBytes!.isEmpty
-                            ? const Icon(Icons.person)
-                            : null,
-                      ),
-                    ),
-                    TextFormField(
-                      controller: nameController,
-                      decoration: InputDecoration(
-                          labelText:
-                              AppLocalizations.of(context)!.nameLabel),
-                      validator: (value) => value == null || value.trim().isEmpty
-                          ? AppLocalizations.of(context)!.nameRequired
-                          : null,
-                    ),
-                    CheckboxListTile(
-                      value: roles.contains(UserRole.customer),
-                      title: Text(AppLocalizations.of(context)!.customerRole),
-                      onChanged: (value) {
-                        setState(() {
-                          if (value == true) {
-                            roles.add(UserRole.customer);
-                          } else {
-                            roles.remove(UserRole.customer);
+    try {
+      await showDialog(
+        context: context,
+        builder: (_) => StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: Text(user == null
+                  ? AppLocalizations.of(context)!.newUserTitle
+                  : AppLocalizations.of(context)!.editUserTitle),
+              content: Form(
+                key: formKey,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      GestureDetector(
+                        onTap: () async {
+                          if (!isImagePickerSupported) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                    AppLocalizations.of(context)!
+                                        .imageSelectionUnsupported),
+                              ),
+                            );
+                            return;
                           }
-                        });
-                      },
-                    ),
-                    CheckboxListTile(
-                      value: roles.contains(UserRole.professional),
-                      title: Text(AppLocalizations.of(context)!.professionalRole),
-                      onChanged: (value) {
-                        setState(() {
-                          if (value == true) {
-                            roles.add(UserRole.professional);
-                          } else {
-                            roles.remove(UserRole.professional);
+                          final bytes = await pickImageBytes();
+                          if (bytes != null) {
+                            setState(() => photoBytes = bytes);
                           }
-                        });
-                      },
-                    ),
-                    if (roles.contains(UserRole.professional))
-                      ...ServiceType.values.map(
-                        (s) => CheckboxListTile(
-                          value: selectedServices.contains(s),
-                          title: Text(s.name),
-                          onChanged: (value) {
-                            setState(() {
-                              if (value == true) {
-                                selectedServices.add(s);
-                              } else {
-                                selectedServices.remove(s);
-                              }
-                            });
-                          },
+                        },
+                        child: CircleAvatar(
+                          radius: 30,
+                          backgroundImage: photoBytes != null
+                              ? MemoryImage(photoBytes!)
+                              : null,
+                          child: photoBytes == null || photoBytes!.isEmpty
+                              ? const Icon(Icons.person)
+                              : null,
                         ),
                       ),
-                  ],
+                      TextFormField(
+                        controller: nameController,
+                        decoration: InputDecoration(
+                            labelText:
+                                AppLocalizations.of(context)!.nameLabel),
+                        validator: (value) =>
+                            value == null || value.trim().isEmpty
+                                ? AppLocalizations.of(context)!.nameRequired
+                                : null,
+                      ),
+                      CheckboxListTile(
+                        value: roles.contains(UserRole.customer),
+                        title: Text(AppLocalizations.of(context)!.customerRole),
+                        onChanged: (value) {
+                          setState(() {
+                            if (value == true) {
+                              roles.add(UserRole.customer);
+                            } else {
+                              roles.remove(UserRole.customer);
+                            }
+                          });
+                        },
+                      ),
+                      CheckboxListTile(
+                        value: roles.contains(UserRole.professional),
+                        title:
+                            Text(AppLocalizations.of(context)!.professionalRole),
+                        onChanged: (value) {
+                          setState(() {
+                            if (value == true) {
+                              roles.add(UserRole.professional);
+                            } else {
+                              roles.remove(UserRole.professional);
+                            }
+                          });
+                        },
+                      ),
+                      if (roles.contains(UserRole.professional))
+                        ...ServiceType.values.map(
+                          (s) => CheckboxListTile(
+                            value: selectedServices.contains(s),
+                            title: Text(s.name),
+                            onChanged: (value) {
+                              setState(() {
+                                if (value == true) {
+                                  selectedServices.add(s);
+                                } else {
+                                  selectedServices.remove(s);
+                                }
+                              });
+                            },
+                          ),
+                        ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text(AppLocalizations.of(context)!.cancelButton),
-              ),
-              TextButton(
-                onPressed: () async {
-                  if (!formKey.currentState!.validate() || roles.isEmpty) return;
-                  if (roles.contains(UserRole.professional) &&
-                      selectedServices.isEmpty) {
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: Text(AppLocalizations.of(context)!.cancelButton),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    if (!formKey.currentState!.validate() || roles.isEmpty) {
+                      return;
+                    }
+                    if (roles.contains(UserRole.professional) &&
+                        selectedServices.isEmpty) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text(AppLocalizations.of(context)!
                               .selectAtLeastOneService),
                         ),
                       );
-                    return;
-                  }
-                  final service = context.read<AppointmentService>();
-                  final id = user?.id ??
-                      DateTime.now().millisecondsSinceEpoch.toString();
-                  final newUser = UserProfile(
-                    id: id,
-                    name: nameController.text,
-                    photoBytes: photoBytes,
-                    roles: roles,
-                    services: roles.contains(UserRole.professional)
-                        ? selectedServices
-                        : <ServiceType>{},
-                  );
-                  if (user == null) {
-                    await service.addUser(newUser);
-                  } else {
-                    await service.updateUser(newUser);
-                  }
-                  Navigator.pop(context);
-                },
-                child: Text(AppLocalizations.of(context)!.saveButton),
-              ),
-            ],
-          );
-        },
-      ),
-    );
-    await Future.delayed(Duration.zero);
-    nameController.dispose();
+                      return;
+                    }
+                    final service = context.read<AppointmentService>();
+                    final id = user?.id ??
+                        DateTime.now().millisecondsSinceEpoch.toString();
+                    final newUser = UserProfile(
+                      id: id,
+                      name: nameController.text,
+                      photoBytes: photoBytes,
+                      roles: roles,
+                      services: roles.contains(UserRole.professional)
+                          ? selectedServices
+                          : <ServiceType>{},
+                    );
+                    if (user == null) {
+                      await service.addUser(newUser);
+                    } else {
+                      await service.updateUser(newUser);
+                    }
+                    Navigator.pop(context);
+                  },
+                  child: Text(AppLocalizations.of(context)!.saveButton),
+                ),
+              ],
+            );
+          },
+        ),
+      );
+    } finally {
+      nameController.dispose();
+    }
   }
 }

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -10,16 +10,18 @@ class AppointmentService extends ChangeNotifier {
   static const _appointmentsBoxName = 'appointments';
   static const _usersBoxName = 'users';
 
-  late Box<Map<String, dynamic>> _appointmentsBox;
-  late Box<Map<String, dynamic>> _usersBox;
+  /// Underlying storage boxes. Hive may return values as
+  /// `Map<dynamic, dynamic>` regardless of the generics provided. Using
+  /// untyped boxes prevents runtime cast errors when retrieving stored maps.
+  late Box _appointmentsBox;
+  late Box _usersBox;
 
   bool _initialized = false;
   bool get isInitialized => _initialized;
 
   Future<void> init() async {
-    _appointmentsBox =
-        await Hive.openBox<Map<String, dynamic>>(_appointmentsBoxName);
-    _usersBox = await Hive.openBox<Map<String, dynamic>>(_usersBoxName);
+    _appointmentsBox = await Hive.openBox(_appointmentsBoxName);
+    _usersBox = await Hive.openBox(_usersBoxName);
     _initialized = true;
   }
 

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -36,7 +36,7 @@ void main() {
     final service = AppointmentService();
     await service.init();
 
-    final box = Hive.box<Map<String, dynamic>>('appointments');
+    final box = Hive.box('appointments');
     await box.put('a1', {
       'id': 'a1',
       'clientId': 'c1',
@@ -53,8 +53,8 @@ void main() {
     final service = AppointmentService();
     await service.init();
 
-    final apptsBox = Hive.box<Map<String, dynamic>>('appointments');
-    final usersBox = Hive.box<Map<String, dynamic>>('users');
+    final apptsBox = Hive.box('appointments');
+    final usersBox = Hive.box('users');
 
     await usersBox.put('c1', UserProfile(id: 'c1', name: 'Client').toMap());
 

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     await service.register(email, password);
 
-    final box = Hive.box<Map<String, String>>('auth');
+    final box = Hive.box('auth');
     final stored = box.get('users')![email]!;
     final expected = sha256.convert(utf8.encode(password)).toString();
     expect(stored, expected);
@@ -71,7 +71,7 @@ void main() {
     const password = 'pass123';
     final hashed = sha256.convert(utf8.encode(password)).toString();
 
-    final box = Hive.box<Map<String, String>>('auth');
+    final box = Hive.box('auth');
     await box.put('users', {email: hashed});
 
     final success = await service.login(email, password);


### PR DESCRIPTION
## Summary
- Use untyped Hive boxes in `AppointmentService` to avoid runtime `Map<String,dynamic>` cast issues
- Adjust tests to work with untyped boxes
- Dispose dialog controller only after closing to prevent using a `TextEditingController` after it's been disposed

## Testing
- `dart format lib/screens/edit_user_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d46f95718832b91ded8f2b91521e8