### PR TITLE
Add localized required field messages for auth page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,6 +48,8 @@
   "registerTitle": "Register",
   "emailLabel": "Email",
   "passwordLabel": "Password",
+  "emailRequired": "Please enter your email",
+  "passwordRequired": "Please enter your password",
   "loginButton": "Login",
   "registerButton": "Register",
   "createAccount": "Create an account",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -48,6 +48,8 @@
   "registerTitle": "Registrarse",
   "emailLabel": "Correo electrónico",
   "passwordLabel": "Contraseña",
+  "emailRequired": "Por favor ingresa tu correo electrónico",
+  "passwordRequired": "Por favor ingresa tu contraseña",
   "loginButton": "Ingresar",
   "registerButton": "Registrarse",
   "createAccount": "Crear una cuenta",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -383,6 +383,18 @@ abstract class AppLocalizations {
   /// **'Password'**
   String get passwordLabel;
 
+  /// No description provided for @emailRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email'**
+  String get emailRequired;
+
+  /// No description provided for @passwordRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your password'**
+  String get passwordRequired;
+
   /// No description provided for @loginButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -153,6 +153,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get passwordLabel => 'Password';
 
   @override
+  String get emailRequired => 'Please enter your email';
+
+  @override
+  String get passwordRequired => 'Please enter your password';
+
+  @override
   String get loginButton => 'Login';
 
   @override
@@ -177,6 +183,5 @@ class AppLocalizationsEn extends AppLocalizations {
   String get guestContactLabel => 'Guest Contact (optional)';
 
   @override
-  String get clientOrGuestValidation =>
-      'Please select a client or enter a guest name';
+  String get clientOrGuestValidation => 'Please select a client or enter a guest name';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -153,6 +153,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get passwordLabel => 'Contraseña';
 
   @override
+  String get emailRequired => 'Por favor ingresa tu correo electrónico';
+
+  @override
+  String get passwordRequired => 'Por favor ingresa tu contraseña';
+
+  @override
   String get loginButton => 'Ingresar';
 
   @override
@@ -177,6 +183,5 @@ class AppLocalizationsEs extends AppLocalizations {
   String get guestContactLabel => 'Contacto del invitado (opcional)';
 
   @override
-  String get clientOrGuestValidation =>
-      'Selecciona un cliente o ingresa un nombre de invitado';
+  String get clientOrGuestValidation => 'Selecciona un cliente o ingresa un nombre de invitado';
 }

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -105,7 +105,7 @@ class _AuthPageState extends State<AuthPage> {
                       ),
                       validator: (value) {
                         if (value == null || value.isEmpty) {
-                          return 'Please enter your email';
+                          return AppLocalizations.of(context)!.emailRequired;
                         }
                         return null;
                       },
@@ -121,7 +121,7 @@ class _AuthPageState extends State<AuthPage> {
                       ),
                       validator: (value) {
                         if (value == null || value.isEmpty) {
-                          return 'Please enter your password';
+                          return AppLocalizations.of(context)!.passwordRequired;
                         }
                         return null;
                       },


### PR DESCRIPTION
## Summary
- add `emailRequired` and `passwordRequired` localization keys in English and Spanish
- regenerate l10n files and use new messages in auth form validators

## Testing
- `flutter gen-l10n`
- `flutter test` *(fails: UserProfile equality profiles with the same values are equal and hashCodes match)*

------
https://chatgpt.com/codex/tasks/task_e_689d4fb0f17c832bb50a61f9970aabca