### PR TITLE
Await deleteUser and handle errors

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -53,7 +53,17 @@ class EditUserPage extends StatelessWidget {
             onTap: () => _showUserDialog(context, user: user),
             trailing: IconButton(
               icon: const Icon(Icons.delete),
-              onPressed: () => service.deleteUser(user.id),
+              onPressed: () async {
+                try {
+                  await service.deleteUser(user.id);
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to delete user'),
+                    ),
+                  );
+                }
+              },
             ),
           );
         },


### PR DESCRIPTION
## Summary
- await `service.deleteUser` and show a snackbar if deletion fails

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d51d552dc832bb57a7937d26e7b68