### PR TITLE
Guard context usage after async calls

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -57,6 +57,7 @@ class EditUserPage extends StatelessWidget {
                 try {
                   await service.deleteUser(user.id);
                 } catch (e) {
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(
                       content: Text('Failed to delete user'),
@@ -218,6 +219,7 @@ class EditUserPage extends StatelessWidget {
                     } else {
                       await service.updateUser(newUser);
                     }
+                    if (!context.mounted) return;
                     Navigator.pop(context);
                   },
                   child: Text(AppLocalizations.of(context)!.saveButton),


### PR DESCRIPTION
## Summary
- Prevent user deletion SnackBar from firing when context is unmounted
- Ensure dialog closes only when context is mounted

## Testing
- `/tmp/dart-sdk/dart-sdk/bin/dart analyze` *(fails: missing Flutter SDK and numerous analysis errors)*
- `/tmp/dart-sdk/dart-sdk/bin/dart test` *(fails: project requires Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689d53a562d0832b9f0ce86fbbbbc41d