### PR TITLE
Format appointment date with intl

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/appointment.dart';
@@ -204,7 +205,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               const SizedBox(height: 12),
               Row(
                 children: [
-                  Text(_dateTime.toLocal().toString()),
+                  Text(DateFormat.yMMMd().add_jm().format(_dateTime.toLocal())),
                   const SizedBox(width: 8),
                   TextButton(
                     onPressed: () async {

--- a/test/utils/date_format_test.dart
+++ b/test/utils/date_format_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+void main() {
+  test('formats date and time in localized style', () {
+    Intl.defaultLocale = 'en_US';
+    final dt = DateTime(2023, 9, 10, 10, 0);
+    final formatted = DateFormat.yMMMd().add_jm().format(dt);
+    expect(formatted, 'Sep 10, 2023 10:00 AM');
+  });
+}
+


### PR DESCRIPTION
## Summary
- format appointment date with intl DateFormat
- add unit test for formatted output

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d55bc4cd4832ba7a3ae96d36e436b