### PR TITLE
Specify base href for GitHub Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           channel: stable
       - run: flutter pub get
-      - run: flutter build web --release
+      - run: flutter build web --release --base-href /vogue_vault/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build/web


### PR DESCRIPTION
## Summary
- configure the deploy workflow to build the Flutter web app with a base href for GitHub Pages

## Testing
- `flutter test` *(fails: command not found)*
- `/tmp/bin/act -W .github/workflows/deploy.yml` *(fails: missing Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_689d6ed682c8832b9ca821a25d913f96