### PR TITLE
feat: introduce warm earthy color palette

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,8 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
+import 'utils/color_palette.dart';
+
 import 'screens/auth_page.dart';
 import 'services/appointment_service.dart';
 import 'services/auth_service.dart';
@@ -44,11 +46,17 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const seed = Colors.deepPurple;
-    final lightScheme = ColorScheme.fromSeed(seedColor: seed);
+    final lightScheme = ColorScheme.fromSeed(
+      seedColor: AppColors.primary,
+    ).copyWith(
+      background: AppColors.base,
+      secondary: AppColors.accent,
+    );
     final darkScheme = ColorScheme.fromSeed(
-      seedColor: seed,
+      seedColor: AppColors.primary,
       brightness: Brightness.dark,
+    ).copyWith(
+      secondary: AppColors.accent,
     );
 
     return MaterialApp(
@@ -56,6 +64,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: lightScheme,
+        scaffoldBackgroundColor: AppColors.base,
         fontFamily: 'Poppins',
         textTheme: const TextTheme(
           headlineLarge: TextStyle(

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../services/auth_service.dart';
+import '../utils/color_palette.dart';
 import 'role_selection_page.dart';
 
 class AuthPage extends StatefulWidget {
@@ -79,7 +80,7 @@ class _AuthPageState extends State<AuthPage> {
         width: double.infinity,
         decoration: const BoxDecoration(
           gradient: LinearGradient(
-            colors: [Color(0xFF8E2DE2), Color(0xFF4A00E0)],
+            colors: [AppColors.primary, AppColors.accent],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
           ),
@@ -101,7 +102,7 @@ class _AuthPageState extends State<AuthPage> {
                       hintText: AppLocalizations.of(context)!.emailLabel,
                       prefixIcon: const Icon(Icons.email),
                       filled: true,
-                      fillColor: Colors.white,
+                      fillColor: AppColors.base,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(30),
                         borderSide: BorderSide.none,
@@ -122,7 +123,7 @@ class _AuthPageState extends State<AuthPage> {
                       hintText: AppLocalizations.of(context)!.passwordLabel,
                       prefixIcon: const Icon(Icons.lock),
                       filled: true,
-                      fillColor: Colors.white,
+                      fillColor: AppColors.base,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(30),
                         borderSide: BorderSide.none,
@@ -165,8 +166,8 @@ class _AuthPageState extends State<AuthPage> {
                       });
                     },
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.white,
-                      side: const BorderSide(color: Colors.white),
+                      foregroundColor: AppColors.base,
+                      side: const BorderSide(color: AppColors.base),
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(30),

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// App-wide color constants for the warm earthy palette.
+class AppColors {
+  /// Base color: off-white or soft beige.
+  static const Color base = Color(0xFFF5F0E8);
+
+  /// Primary elements: dark espresso brown.
+  static const Color primary = Color(0xFF4E3828);
+
+  /// Accent color: rich amber or burnt orange.
+  static const Color accent = Color(0xFFE48815);
+
+  /// A lighter accent variant.
+  static const Color accentLight = Color(0xFFFCCC7C);
+}


### PR DESCRIPTION
## Summary
- define AppColors with espresso, beige, and amber tones
- use new palette in Material color schemes
- refresh auth page gradient and inputs to match palette

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d7307eaf0832bbbca8195785d530c