### PR TITLE
Add structured name fields to UserProfile

### DIFF
--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -11,8 +11,14 @@ class UserProfile {
   /// Unique identifier for the user.
   final String id;
 
-  /// Display name of the user.
-  final String name;
+  /// The user's given name.
+  final String firstName;
+
+  /// The user's family name.
+  final String lastName;
+
+  /// Optional nickname for the user.
+  final String? nickname;
 
   /// Optional raw bytes of a profile image.
   final Uint8List? photoBytes;
@@ -25,7 +31,9 @@ class UserProfile {
 
   UserProfile({
     required this.id,
-    required this.name,
+    required this.firstName,
+    required this.lastName,
+    this.nickname,
     this.photoBytes,
     Set<UserRole>? roles,
     Set<ServiceType>? services,
@@ -33,17 +41,24 @@ class UserProfile {
         roles = Set.unmodifiable(roles ?? <UserRole>{}),
         services = Set.unmodifiable(services ?? <ServiceType>{});
 
+  /// The full display name for the user.
+  String get fullName => nickname ?? '$firstName $lastName';
+
   /// Returns a copy of this profile with the given fields replaced.
   UserProfile copyWith({
     String? id,
-    String? name,
+    String? firstName,
+    String? lastName,
+    String? nickname,
     Uint8List? photoBytes,
     Set<UserRole>? roles,
     Set<ServiceType>? services,
   }) {
     return UserProfile(
       id: id ?? this.id,
-      name: name ?? this.name,
+      firstName: firstName ?? this.firstName,
+      lastName: lastName ?? this.lastName,
+      nickname: nickname ?? this.nickname,
       photoBytes: photoBytes ?? this.photoBytes,
       roles: roles != null ? Set.unmodifiable(roles) : this.roles,
       services: services != null ? Set.unmodifiable(services) : this.services,
@@ -54,7 +69,9 @@ class UserProfile {
   factory UserProfile.fromMap(Map<String, dynamic> map) {
     return UserProfile(
       id: map['id'] as String,
-      name: map['name'] as String,
+      firstName: map['firstName'] as String,
+      lastName: map['lastName'] as String,
+      nickname: map['nickname'] as String?,
       photoBytes: map['photoBytes'] != null
           ? base64Decode(map['photoBytes'] as String)
           : null,
@@ -75,7 +92,9 @@ class UserProfile {
   Map<String, dynamic> toMap() {
     return {
       'id': id,
-      'name': name,
+      'firstName': firstName,
+      'lastName': lastName,
+      'nickname': nickname,
       'photoBytes': photoBytes != null ? base64Encode(photoBytes!) : null,
       'roles': roles.map((e) => e.name).toList(),
       'services': services.map((e) => e.name).toList(),
@@ -88,7 +107,9 @@ class UserProfile {
       other is UserProfile &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          name == other.name &&
+          firstName == other.firstName &&
+          lastName == other.lastName &&
+          nickname == other.nickname &&
           const ListEquality<int>().equals(photoBytes, other.photoBytes) &&
           const SetEquality<UserRole>().equals(roles, other.roles) &&
           const SetEquality<ServiceType>().equals(services, other.services);
@@ -96,7 +117,9 @@ class UserProfile {
   @override
   int get hashCode =>
       id.hashCode ^
-      name.hashCode ^
+      firstName.hashCode ^
+      lastName.hashCode ^
+      nickname.hashCode ^
       const ListEquality<int>().hash(photoBytes) ^
       roles.hashCode ^
       services.hashCode;

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -48,7 +48,7 @@ class EditUserPage extends StatelessWidget {
                   ? const Icon(Icons.person)
                   : null,
             ),
-            title: Text(user.name),
+            title: Text(user.fullName),
             subtitle: Text(roleText),
             onTap: () => _showUserDialog(context, user: user),
             trailing: IconButton(
@@ -77,7 +77,7 @@ class EditUserPage extends StatelessWidget {
   }
 
   Future<void> _showUserDialog(BuildContext context, {UserProfile? user}) async {
-    final nameController = TextEditingController(text: user?.name ?? '');
+    final nameController = TextEditingController(text: user?.fullName ?? '');
     final formKey = GlobalKey<FormState>();
     Uint8List? photoBytes = user?.photoBytes;
     final roles = <UserRole>{...user?.roles ?? {}};
@@ -205,9 +205,15 @@ class EditUserPage extends StatelessWidget {
                     final service = context.read<AppointmentService>();
                     final id = user?.id ??
                         DateTime.now().millisecondsSinceEpoch.toString();
+                    final parts =
+                        nameController.text.trim().split(RegExp(r'\s+'));
+                    final first = parts.isNotEmpty ? parts.first : '';
+                    final last =
+                        parts.length > 1 ? parts.sublist(1).join(' ') : '';
                     final newUser = UserProfile(
                       id: id,
-                      name: nameController.text,
+                      firstName: first,
+                      lastName: last,
                       photoBytes: photoBytes,
                       roles: roles,
                       services: roles.contains(UserRole.professional)

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -36,7 +36,7 @@ class _ProfilePageState extends State<ProfilePage> {
     final roleProvider = context.read<RoleProvider>();
     _userId = auth.currentUser ?? DateTime.now().millisecondsSinceEpoch.toString();
     final user = service.getUser(_userId);
-    _nameController.text = user?.name ?? '';
+    _nameController.text = user?.fullName ?? '';
     _photoBytes = user?.photoBytes;
     _roles = {...(user?.roles ?? roleProvider.roles)};
     _services = {...(user?.services ?? <ServiceType>{})};
@@ -66,9 +66,13 @@ class _ProfilePageState extends State<ProfilePage> {
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
     final service = context.read<AppointmentService>();
+    final parts = _nameController.text.trim().split(RegExp(r'\s+'));
+    final first = parts.isNotEmpty ? parts.first : '';
+    final last = parts.length > 1 ? parts.sublist(1).join(' ') : '';
     final user = UserProfile(
       id: _userId,
-      name: _nameController.text,
+      firstName: first,
+      lastName: last,
       photoBytes: _photoBytes,
       roles: _roles,
       services: _services,

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -10,7 +10,9 @@ void main() {
     test('toMap and fromMap produce equivalent objects', () {
       final profile = UserProfile(
         id: 'u1',
-        name: 'Alice',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        nickname: 'Ally',
         photoBytes: Uint8List.fromList([1, 2, 3]),
         roles: {UserRole.customer, UserRole.professional},
         services: {ServiceType.barber, ServiceType.nails},
@@ -20,20 +22,24 @@ void main() {
       final from = UserProfile.fromMap(map);
 
       expect(from, equals(profile));
+      expect(from.fullName, 'Ally');
     });
 
     test('handles null photoBytes and empty sets', () {
       final profile = UserProfile(
         id: 'u2',
-        name: 'Bob',
+        firstName: 'Bob',
+        lastName: 'Builder',
       );
 
       final map = profile.toMap();
       final from = UserProfile.fromMap(map);
 
       expect(from.photoBytes, isNull);
+      expect(from.nickname, isNull);
       expect(from.roles, isEmpty);
       expect(from.services, isEmpty);
+      expect(from.fullName, 'Bob Builder');
       expect(from, equals(profile));
     });
   });
@@ -42,13 +48,17 @@ void main() {
     test('profiles with the same values are equal and hashCodes match', () {
       final p1 = UserProfile(
         id: 'u1',
-        name: 'Alice',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        nickname: 'Ally',
         roles: {UserRole.customer, UserRole.professional},
         services: {ServiceType.barber},
       );
       final p2 = UserProfile(
         id: 'u1',
-        name: 'Alice',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        nickname: 'Ally',
         roles: {UserRole.professional, UserRole.customer},
         services: {ServiceType.barber},
       );
@@ -60,11 +70,14 @@ void main() {
     test('profiles with different data are not equal', () {
       final p1 = UserProfile(
         id: 'u1',
-        name: 'Alice',
+        firstName: 'Alice',
+        lastName: 'Smith',
       );
       final p2 = UserProfile(
-        id: 'u2',
-        name: 'Alice',
+        id: 'u1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        nickname: 'Ally',
       );
 
       expect(p1, isNot(equals(p2)));

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -56,7 +56,13 @@ void main() {
     final apptsBox = Hive.box('appointments');
     final usersBox = Hive.box('users');
 
-    await usersBox.put('c1', UserProfile(id: 'c1', name: 'Client').toMap());
+    await usersBox.put(
+        'c1',
+        UserProfile(
+          id: 'c1',
+          firstName: 'Client',
+          lastName: 'User',
+        ).toMap());
 
     await apptsBox.put('a1', {
       'id': 'a1',


### PR DESCRIPTION
## Summary
- add firstName, lastName, optional nickname, and computed fullName to UserProfile
- update serialization, copyWith, and equality for new fields
- update UI and tests to use structured name fields

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d785befc8832b91a729b4fc10963e