### PR TITLE
Refactor services to service offerings

### DIFF
--- a/lib/models/service_offering.dart
+++ b/lib/models/service_offering.dart
@@ -1,0 +1,61 @@
+import 'service_type.dart';
+
+/// Represents a specific service a professional offers including name and price.
+class ServiceOffering {
+  /// The type of service.
+  final ServiceType type;
+
+  /// The display name of the service.
+  final String name;
+
+  /// The price of the service.
+  final double price;
+
+  const ServiceOffering({
+    required this.type,
+    required this.name,
+    required this.price,
+  });
+
+  /// Creates a copy of this offering with optional replacements.
+  ServiceOffering copyWith({
+    ServiceType? type,
+    String? name,
+    double? price,
+  }) {
+    return ServiceOffering(
+      type: type ?? this.type,
+      name: name ?? this.name,
+      price: price ?? this.price,
+    );
+  }
+
+  /// Converts this offering into a JSON-compatible map.
+  Map<String, dynamic> toMap() => {
+        'type': type.name,
+        'name': name,
+        'price': price,
+      };
+
+  /// Creates a [ServiceOffering] from a JSON-compatible [map].
+  factory ServiceOffering.fromMap(Map<String, dynamic> map) {
+    return ServiceOffering(
+      type: ServiceType.values.byName(map['type'] as String),
+      name: map['name'] as String,
+      price: (map['price'] as num).toDouble(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ServiceOffering &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          name == other.name &&
+          price == other.price;
+
+  @override
+  int get hashCode => type.hashCode ^ name.hashCode ^ price.hashCode;
+}
+

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -52,7 +52,10 @@ class AppointmentService extends ChangeNotifier {
       final userMap = Map<String, dynamic>.from(m);
       return UserProfile.fromMap({
         ...userMap,
-        'services': userMap['services'] ?? <String>[],
+        'offerings': (userMap['offerings'] as List?)
+                ?.map((e) => Map<String, dynamic>.from(e as Map))
+                .toList() ??
+            <Map<String, dynamic>>[],
       });
     }).toList();
   }
@@ -64,7 +67,9 @@ class AppointmentService extends ChangeNotifier {
       users.where((u) => u.roles.contains(UserRole.professional)).toList();
 
   List<UserProfile> providersFor(ServiceType type) =>
-      providers.where((p) => p.services.contains(type)).toList();
+      providers
+          .where((p) => p.offerings.any((o) => o.type == type))
+          .toList();
 
   UserProfile? getUser(String id) {
     _ensureInitialized();
@@ -73,7 +78,10 @@ class AppointmentService extends ChangeNotifier {
     final userMap = Map<String, dynamic>.from(map);
     return UserProfile.fromMap({
       ...userMap,
-      'services': userMap['services'] ?? <String>[],
+      'offerings': (userMap['offerings'] as List?)
+              ?.map((e) => Map<String, dynamic>.from(e as Map))
+              .toList() ??
+          <Map<String, dynamic>>[],
     });
   }
 

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/models/user_role.dart';
 import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/models/service_offering.dart';
 
 void main() {
   group('UserProfile serialization', () {
@@ -15,7 +16,10 @@ void main() {
         nickname: 'Ally',
         photoBytes: Uint8List.fromList([1, 2, 3]),
         roles: {UserRole.customer, UserRole.professional},
-        services: {ServiceType.barber, ServiceType.nails},
+        offerings: [
+          ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
+          ServiceOffering(type: ServiceType.nails, name: 'Nail', price: 15),
+        ],
       );
 
       final map = profile.toMap();
@@ -38,7 +42,7 @@ void main() {
       expect(from.photoBytes, isNull);
       expect(from.nickname, isNull);
       expect(from.roles, isEmpty);
-      expect(from.services, isEmpty);
+      expect(from.offerings, isEmpty);
       expect(from.fullName, 'Bob Builder');
       expect(from, equals(profile));
     });
@@ -52,7 +56,9 @@ void main() {
         lastName: 'Smith',
         nickname: 'Ally',
         roles: {UserRole.customer, UserRole.professional},
-        services: {ServiceType.barber},
+        offerings: [
+          ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
+        ],
       );
       final p2 = UserProfile(
         id: 'u1',
@@ -60,7 +66,9 @@ void main() {
         lastName: 'Smith',
         nickname: 'Ally',
         roles: {UserRole.professional, UserRole.customer},
-        services: {ServiceType.barber},
+        offerings: [
+          ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
+        ],
       );
 
       expect(p1, equals(p2));

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -8,6 +8,8 @@ import 'package:vogue_vault/services/appointment_service.dart';
 import 'package:vogue_vault/models/service_type.dart';
 import 'package:vogue_vault/models/appointment.dart';
 import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/models/service_offering.dart';
+import 'package:vogue_vault/models/user_role.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   @override
@@ -92,5 +94,38 @@ void main() {
     final stored = service.getAppointment('a2');
     expect(stored?.guestName, 'Walk-in');
     expect(stored?.clientId, isNull);
+  });
+
+  test('providersFor filters by offerings', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    final p1 = UserProfile(
+      id: 'p1',
+      firstName: 'Pro',
+      lastName: 'One',
+      roles: {UserRole.professional},
+      offerings: [
+        ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
+      ],
+    );
+    final p2 = UserProfile(
+      id: 'p2',
+      firstName: 'Pro',
+      lastName: 'Two',
+      roles: {UserRole.professional},
+      offerings: [
+        ServiceOffering(type: ServiceType.nails, name: 'Nail', price: 20),
+      ],
+    );
+
+    await service.addUser(p1);
+    await service.addUser(p2);
+
+    final barbers = service.providersFor(ServiceType.barber);
+    expect(barbers.map((p) => p.id), ['p1']);
+
+    final nailTechs = service.providersFor(ServiceType.nails);
+    expect(nailTechs.map((p) => p.id), ['p2']);
   });
 }


### PR DESCRIPTION
## Summary
- add `ServiceOffering` model with type, name and price
- store professional offerings in `UserProfile` and persist via `AppointmentService`
- update profile and user edit pages for dynamic offering management
- adjust tests for new offering structure and provider filtering

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689d7eab705c832ba65dc49a0a38049a