### PR TITLE
Align UserProfile hashCode with role equality

### DIFF
--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -135,7 +135,7 @@ class UserProfile {
       lastName.hashCode ^
       nickname.hashCode ^
       const ListEquality<int>().hash(photoBytes) ^
-      roles.hashCode ^
+      const SetEquality<UserRole>().hash(roles) ^
       const ListEquality<ServiceOffering>().hash(offerings);
 }
 


### PR DESCRIPTION
## Summary
- Use `SetEquality` to hash `UserProfile.roles`, matching equality semantics

## Testing
- `dart format lib/models/user_profile.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de0eb73a4832b968db6b31d95cb6b