### PR TITLE
Use salted PBKDF2 for password hashing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   intl: ^0.20.2
   image_picker: ^1.0.4
   file_selector: ^1.0.3
-  crypto: ^3.0.3
+  cryptography: ^2.7.0
   flutter_gen: ^5.9.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- switch to PBKDF2-based password hashing with per-user random salts
- persist salt and hash together and update login logic to verify salted hash
- add cryptography dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de40ac314832b92be959a59be623f