### PR TITLE
feat: add tattoo service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vogue Vault
 
-Vogue Vault is a scheduling platform for barbershops, hairdressers, nail technicians, and other beauty professionals and their clients. Salon owners, barbers, stylists, nail techs, and makeup artists can showcase services, manage calendars, and coordinate appointments in one place.
+Vogue Vault is a scheduling platform for barbershops, hairdressers, nail technicians, tattoo artists, and other beauty professionals and their clients. Salon owners, barbers, stylists, nail techs, tattoo artists, and makeup artists can showcase services, manage calendars, and coordinate appointments in one place.
 
 ## Setup
 
@@ -36,7 +36,7 @@ flutter pub get
 
 ## Core Features
 
-- Browse profiles and services for barbers, hairdressers, nail technicians, and other beauty professionals
+- Browse profiles and services for barbers, hairdressers, nail technicians, tattoo artists, and other beauty professionals
 - Book, reschedule, and cancel appointments across all service types
 - Manage professional calendars and time slots
 - Local data persistence with Hive
@@ -47,6 +47,7 @@ flutter pub get
 - Barbershop cuts
 - Hair styling and coloring
 - Manicures and pedicures
+- Tattoo design and application
 - Makeup application
 
 ## Roadmap

--- a/lib/models/service_type.dart
+++ b/lib/models/service_type.dart
@@ -8,5 +8,8 @@ enum ServiceType {
 
   /// Manicure or pedicure services.
   nails,
+
+  /// Permanent body art services.
+  tattoo,
 }
 

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -13,6 +13,8 @@ String serviceTypeLabel(ServiceType type) {
       return 'Hairdresser';
     case ServiceType.nails:
       return 'Nails';
+    case ServiceType.tattoo:
+      return 'Tattoo Artist';
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');
@@ -29,6 +31,8 @@ IconData serviceTypeIcon(ServiceType type) {
       return Icons.brush;
     case ServiceType.nails:
       return Icons.spa;
+    case ServiceType.tattoo:
+      return Icons.edit;
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');
@@ -45,6 +49,8 @@ Color serviceTypeColor(ServiceType type) {
       return Colors.purple;
     case ServiceType.nails:
       return Colors.pink;
+    case ServiceType.tattoo:
+      return Colors.black;
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -19,6 +19,7 @@ void main() {
         offerings: [
           ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
           ServiceOffering(type: ServiceType.nails, name: 'Nail', price: 15),
+          ServiceOffering(type: ServiceType.tattoo, name: 'Ink', price: 25),
         ],
       );
 
@@ -58,6 +59,7 @@ void main() {
         roles: {UserRole.customer, UserRole.professional},
         offerings: [
           ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
+          ServiceOffering(type: ServiceType.tattoo, name: 'Ink', price: 50),
         ],
       );
       final p2 = UserProfile(
@@ -68,6 +70,7 @@ void main() {
         roles: {UserRole.professional, UserRole.customer},
         offerings: [
           ServiceOffering(type: ServiceType.barber, name: 'Cut', price: 10),
+          ServiceOffering(type: ServiceType.tattoo, name: 'Ink', price: 50),
         ],
       );
 

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -118,14 +118,27 @@ void main() {
         ServiceOffering(type: ServiceType.nails, name: 'Nail', price: 20),
       ],
     );
+    final p3 = UserProfile(
+      id: 'p3',
+      firstName: 'Pro',
+      lastName: 'Three',
+      roles: {UserRole.professional},
+      offerings: [
+        ServiceOffering(type: ServiceType.tattoo, name: 'Ink', price: 50),
+      ],
+    );
 
     await service.addUser(p1);
     await service.addUser(p2);
+    await service.addUser(p3);
 
     final barbers = service.providersFor(ServiceType.barber);
     expect(barbers.map((p) => p.id), ['p1']);
 
     final nailTechs = service.providersFor(ServiceType.nails);
     expect(nailTechs.map((p) => p.id), ['p2']);
+
+    final tattooArtists = service.providersFor(ServiceType.tattoo);
+    expect(tattooArtists.map((p) => p.id), ['p3']);
   });
 }


### PR DESCRIPTION
## Summary
- add `tattoo` option to `ServiceType` enum
- support tattoo artists in service type utilities
- test and document tattoo offerings

## Testing
- `dart format lib test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df640eee4832bb588bb19d9c254d4