### PR TITLE
Handle unknown service types safely

### DIFF
--- a/lib/models/service_offering.dart
+++ b/lib/models/service_offering.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'service_type.dart';
 
 /// Represents a specific service a professional offers including name and price.
@@ -39,8 +41,18 @@ class ServiceOffering {
 
   /// Creates a [ServiceOffering] from a JSON-compatible [map].
   factory ServiceOffering.fromMap(Map<String, dynamic> map) {
+    final typeName = map['type'] as String?;
+    final serviceType = ServiceType.values.firstWhere(
+      (e) => e.name == typeName,
+      orElse: () {
+        developer.log('Unknown service type: $typeName',
+            name: 'ServiceOffering');
+        return ServiceType.values.first;
+      },
+    );
+
     return ServiceOffering(
-      type: ServiceType.values.byName(map['type'] as String),
+      type: serviceType,
       name: map['name'] as String,
       price: (map['price'] as num).toDouble(),
     );

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
@@ -92,10 +93,18 @@ class UserProfile {
                   .toList() ??
               (map['services'] as List?)
                       ?.map((e) {
-                        final type = ServiceType.values.byName(e as String);
+                        final typeName = e as String;
+                        final type = ServiceType.values
+                            .firstWhereOrNull((t) => t.name == typeName);
+                        if (type == null) {
+                          developer.log('Unknown service type: $typeName',
+                              name: 'UserProfile');
+                          return null;
+                        }
                         return ServiceOffering(
                             type: type, name: type.name, price: 0);
                       })
+                      .whereType<ServiceOffering>()
                       .toList() ??
                   <ServiceOffering>[]),
     );

--- a/test/models/service_offering_test.dart
+++ b/test/models/service_offering_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vogue_vault/models/service_offering.dart';
+import 'package:vogue_vault/models/service_type.dart';
+
+void main() {
+  test('defaults to first ServiceType for unknown value', () {
+    final offering = ServiceOffering.fromMap({
+      'type': 'unknown',
+      'name': 'Mystery',
+      'price': 5,
+    });
+
+    expect(offering.type, ServiceType.values.first);
+    expect(offering.name, 'Mystery');
+    expect(offering.price, 5);
+  });
+}
+

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -94,4 +94,36 @@ void main() {
       expect(p1, isNot(equals(p2)));
     });
   });
+
+  group('UserProfile service type parsing', () {
+    test('skips invalid service types in legacy services list', () {
+      final map = {
+        'id': 'u1',
+        'firstName': 'Alice',
+        'lastName': 'Smith',
+        'services': ['barber', 'unknown']
+      };
+
+      final profile = UserProfile.fromMap(map);
+
+      expect(profile.offerings, hasLength(1));
+      expect(profile.offerings.first.type, ServiceType.barber);
+    });
+
+    test('defaults invalid offering type to first enum value', () {
+      final map = {
+        'id': 'u1',
+        'firstName': 'Alice',
+        'lastName': 'Smith',
+        'offerings': [
+          {'type': 'mystery', 'name': 'Mystery', 'price': 0}
+        ]
+      };
+
+      final profile = UserProfile.fromMap(map);
+
+      expect(profile.offerings, hasLength(1));
+      expect(profile.offerings.first.type, ServiceType.values.first);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Guard service type parsing with safe lookup and warnings
- Skip legacy services with unknown types and default unknown offerings to a fallback
- Add tests ensuring malformed service types don't crash deserialization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dfe129cf0832bb40a06f55e6b14a7