### PR TITLE
Localize service type labels

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -67,5 +67,9 @@
   "addFirstAppointment": "Add your first appointment",
   "guestNameLabel": "Guest Name",
   "guestContactLabel": "Guest Contact (optional)",
-  "clientOrGuestValidation": "Please select a client or enter a guest name"
+  "clientOrGuestValidation": "Please select a client or enter a guest name",
+  "serviceTypeBarber": "Barbershop",
+  "serviceTypeHairdresser": "Hairdresser",
+  "serviceTypeNails": "Nails",
+  "serviceTypeTattoo": "Tattoo Artist"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -67,5 +67,9 @@
   "addFirstAppointment": "Agrega tu primera cita",
   "guestNameLabel": "Nombre del invitado",
   "guestContactLabel": "Contacto del invitado (opcional)",
-  "clientOrGuestValidation": "Selecciona un cliente o ingresa un nombre de invitado"
+  "clientOrGuestValidation": "Selecciona un cliente o ingresa un nombre de invitado",
+  "serviceTypeBarber": "Barbería",
+  "serviceTypeHairdresser": "Peluquería",
+  "serviceTypeNails": "Uñas",
+  "serviceTypeTattoo": "Tatuador"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -502,6 +502,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Please select a client or enter a guest name'**
   String get clientOrGuestValidation;
+
+  /// No description provided for @serviceTypeBarber.
+  ///
+  /// In en, this message translates to:
+  /// **'Barbershop'**
+  String get serviceTypeBarber;
+
+  /// No description provided for @serviceTypeHairdresser.
+  ///
+  /// In en, this message translates to:
+  /// **'Hairdresser'**
+  String get serviceTypeHairdresser;
+
+  /// No description provided for @serviceTypeNails.
+  ///
+  /// In en, this message translates to:
+  /// **'Nails'**
+  String get serviceTypeNails;
+
+  /// No description provided for @serviceTypeTattoo.
+  ///
+  /// In en, this message translates to:
+  /// **'Tattoo Artist'**
+  String get serviceTypeTattoo;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -211,4 +211,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get clientOrGuestValidation => 'Please select a client or enter a guest name';
+
+  @override
+  String get serviceTypeBarber => 'Barbershop';
+
+  @override
+  String get serviceTypeHairdresser => 'Hairdresser';
+
+  @override
+  String get serviceTypeNails => 'Nails';
+
+  @override
+  String get serviceTypeTattoo => 'Tattoo Artist';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -211,4 +211,16 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get clientOrGuestValidation => 'Selecciona un cliente o ingresa un nombre de invitado';
+
+  @override
+  String get serviceTypeBarber => 'Barbería';
+
+  @override
+  String get serviceTypeHairdresser => 'Peluquería';
+
+  @override
+  String get serviceTypeNails => 'Uñas';
+
+  @override
+  String get serviceTypeTattoo => 'Tatuador';
 }

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -104,7 +104,7 @@ class AppointmentsPage extends StatelessWidget {
                     ),
                   ),
                   title: Text(
-                    '$clientName - ${serviceTypeLabel(appt.service)}',
+                    '$clientName - ${serviceTypeLabel(context, appt.service)}',
                   ),
                   subtitle: Text(
                     DateFormat.yMMMd().add_jm().format(appt.dateTime.toLocal()),

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -164,7 +164,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                     .map(
                       (s) => DropdownMenuItem<ServiceType>(
                         value: s,
-                        child: Text(serviceTypeLabel(s)),
+                        child: Text(serviceTypeLabel(context, s)),
                       ),
                     )
                     .toList(),

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -151,7 +151,7 @@ class _ServiceCard extends StatelessWidget {
           children: [
             visual,
             const SizedBox(height: 8),
-            Text(serviceTypeLabel(type)),
+            Text(serviceTypeLabel(context, type)),
           ],
         ),
       ),

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -1,20 +1,22 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/service_type.dart';
 
-/// Returns a human-readable label for the given [ServiceType].
+/// Returns a localized label for the given [ServiceType].
 ///
 /// The switch is exhaustive; a label is provided for every service type.
-String serviceTypeLabel(ServiceType type) {
+String serviceTypeLabel(BuildContext context, ServiceType type) {
+  final l10n = AppLocalizations.of(context)!;
   switch (type) {
     case ServiceType.barber:
-      return 'Barbershop';
+      return l10n.serviceTypeBarber;
     case ServiceType.hairdresser:
-      return 'Hairdresser';
+      return l10n.serviceTypeHairdresser;
     case ServiceType.nails:
-      return 'Nails';
+      return l10n.serviceTypeNails;
     case ServiceType.tattoo:
-      return 'Tattoo Artist';
+      return l10n.serviceTypeTattoo;
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');

--- a/test/utils/service_type_utils_test.dart
+++ b/test/utils/service_type_utils_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/utils/service_type_utils.dart';
+
+void main() {
+  Future<BuildContext> _pumpApp(WidgetTester tester, Locale? locale) async {
+    late BuildContext ctx;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(builder: (context) {
+          ctx = context;
+          return const SizedBox.shrink();
+        }),
+      ),
+    );
+    return ctx;
+  }
+
+  testWidgets('returns English labels', (tester) async {
+    final context = await _pumpApp(tester, const Locale('en'));
+    expect(serviceTypeLabel(context, ServiceType.barber), 'Barbershop');
+    expect(serviceTypeLabel(context, ServiceType.hairdresser), 'Hairdresser');
+    expect(serviceTypeLabel(context, ServiceType.nails), 'Nails');
+    expect(serviceTypeLabel(context, ServiceType.tattoo), 'Tattoo Artist');
+  });
+
+  testWidgets('returns Spanish labels', (tester) async {
+    final context = await _pumpApp(tester, const Locale('es'));
+    expect(serviceTypeLabel(context, ServiceType.barber), 'Barbería');
+    expect(serviceTypeLabel(context, ServiceType.hairdresser), 'Peluquería');
+    expect(serviceTypeLabel(context, ServiceType.nails), 'Uñas');
+    expect(serviceTypeLabel(context, ServiceType.tattoo), 'Tatuador');
+  });
+}
+


### PR DESCRIPTION
## Summary
- Move service type names into English and Spanish localization files
- Use `AppLocalizations` in `service_type_utils.dart` to fetch localized labels
- Add tests ensuring service type labels are localized in English and Spanish

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `dart format lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e015036e8832b8f935447693449b6