### PR TITLE
feat: refresh app color scheme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,14 +49,17 @@ class MyApp extends StatelessWidget {
     final lightScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primary,
     ).copyWith(
-      background: AppColors.base,
-      secondary: AppColors.accent,
+      background: AppColors.background,
+      secondary: AppColors.secondary,
+      tertiary: AppColors.accent,
     );
     final darkScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primary,
       brightness: Brightness.dark,
     ).copyWith(
-      secondary: AppColors.accent,
+      secondary: AppColors.secondary,
+      tertiary: AppColors.accent,
+      background: AppColors.background,
     );
 
     return MaterialApp(
@@ -64,7 +67,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: lightScheme,
-        scaffoldBackgroundColor: AppColors.base,
+        scaffoldBackgroundColor: AppColors.background,
         fontFamily: 'Poppins',
         textTheme: const TextTheme(
           headlineLarge: TextStyle(
@@ -77,6 +80,7 @@ class MyApp extends StatelessWidget {
       darkTheme: ThemeData(
         useMaterial3: true,
         colorScheme: darkScheme,
+        scaffoldBackgroundColor: AppColors.background,
         fontFamily: 'Poppins',
         textTheme: const TextTheme(
           headlineLarge: TextStyle(

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -100,7 +100,7 @@ class AppointmentsPage extends StatelessWidget {
                     backgroundColor: serviceTypeColor(appt.service),
                     child: Icon(
                       serviceTypeIcon(appt.service),
-                      color: Colors.white,
+                      color: Theme.of(context).colorScheme.onPrimary,
                     ),
                   ),
                   title: Text(

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -90,7 +90,7 @@ class _AuthPageState extends State<AuthPage> {
         width: double.infinity,
         decoration: const BoxDecoration(
           gradient: LinearGradient(
-            colors: [AppColors.primary, AppColors.accent],
+            colors: [AppColors.primary, AppColors.secondary],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
           ),
@@ -112,7 +112,7 @@ class _AuthPageState extends State<AuthPage> {
                       hintText: AppLocalizations.of(context)!.emailLabel,
                       prefixIcon: const Icon(Icons.email),
                       filled: true,
-                      fillColor: AppColors.base,
+                      fillColor: AppColors.background,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(30),
                         borderSide: BorderSide.none,
@@ -133,7 +133,7 @@ class _AuthPageState extends State<AuthPage> {
                       hintText: AppLocalizations.of(context)!.passwordLabel,
                       prefixIcon: const Icon(Icons.lock),
                       filled: true,
-                      fillColor: AppColors.base,
+                      fillColor: AppColors.background,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(30),
                         borderSide: BorderSide.none,
@@ -176,8 +176,8 @@ class _AuthPageState extends State<AuthPage> {
                       });
                     },
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: AppColors.base,
-                      side: const BorderSide(color: AppColors.base),
+                      foregroundColor: AppColors.background,
+                      side: const BorderSide(color: AppColors.background),
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(30),

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 
-/// App-wide color constants for the warm earthy palette.
+/// Centralized application color palette.
 class AppColors {
-  /// Base color: off-white or soft beige.
-  static const Color base = Color(0xFFF5F0E8);
+  /// Primary brand color.
+  static const Color primary = Color(0xFFBB4F12);
 
-  /// Primary elements: dark espresso brown.
-  static const Color primary = Color(0xFF4E3828);
+  /// Secondary complementary color.
+  static const Color secondary = Color(0xFF923B0D);
 
-  /// Accent color: rich amber or burnt orange.
-  static const Color accent = Color(0xFFE48815);
+  /// Background/base color used throughout the app.
+  static const Color background = Color(0xFF4F250F);
 
-  /// A lighter accent variant.
-  static const Color accentLight = Color(0xFFFCCC7C);
+  /// Accent color for highlights and interactive elements.
+  static const Color accent = Color(0xFFDF9C61);
 }

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models/service_type.dart';
+import 'color_palette.dart';
 
 /// Returns a localized label for the given [ServiceType].
 ///
@@ -46,13 +47,13 @@ IconData serviceTypeIcon(ServiceType type) {
 Color serviceTypeColor(ServiceType type) {
   switch (type) {
     case ServiceType.barber:
-      return Colors.blue;
+      return AppColors.primary;
     case ServiceType.hairdresser:
-      return Colors.purple;
+      return AppColors.secondary;
     case ServiceType.nails:
-      return Colors.pink;
+      return AppColors.accent;
     case ServiceType.tattoo:
-      return Colors.black;
+      return AppColors.background;
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');


### PR DESCRIPTION
## Summary
- extract colors from `draft.png` and define them as primary, secondary, background, and accent in `AppColors`
- apply new palette across `ColorScheme`, `ThemeData`, authentication gradient, and service-type utilities
- replace hard-coded whites with theme colors for better consistency

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e057323c8832ba860c7450cb6b2f2