### PR TITLE
Use custom icons for service types

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -98,8 +98,8 @@ class AppointmentsPage extends StatelessWidget {
                 return ListTile(
                   leading: CircleAvatar(
                     backgroundColor: serviceTypeColor(appt.service),
-                    child: Icon(
-                      serviceTypeIcon(appt.service),
+                    child: ImageIcon(
+                      AssetImage(serviceTypeIcon(appt.service)),
                       color: Theme.of(context).colorScheme.onPrimary,
                     ),
                   ),

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -116,8 +116,8 @@ class _ServiceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color color = serviceTypeColor(type);
-    final Widget visual = Icon(
-      serviceTypeIcon(type),
+    final Widget visual = ImageIcon(
+      AssetImage(serviceTypeIcon(type)),
       size: 40,
       color: color,
     );

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -23,19 +23,19 @@ String serviceTypeLabel(BuildContext context, ServiceType type) {
   throw ArgumentError('Unhandled ServiceType: $type');
 }
 
-/// Returns an [IconData] representing the given [ServiceType].
+/// Returns the asset path of an icon representing the given [ServiceType].
 ///
-/// The switch is exhaustive; each service type has a corresponding icon.
-IconData serviceTypeIcon(ServiceType type) {
+/// The switch is exhaustive; each service type has a corresponding asset.
+String serviceTypeIcon(ServiceType type) {
   switch (type) {
     case ServiceType.barber:
-      return Icons.content_cut;
+      return 'razor.png';
     case ServiceType.hairdresser:
-      return Icons.brush;
+      return 'hair-dryer.png';
     case ServiceType.nails:
-      return Icons.spa;
+      return 'nail-polish.png';
     case ServiceType.tattoo:
-      return Icons.edit;
+      return 'tattoo-machine.png';
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,10 @@ flutter:
 
   assets:
     - assets/images/logonobg.png
+    - hair-dryer.png
+    - nail-polish.png
+    - razor.png
+    - tattoo-machine.png
 
   fonts:
     - family: Poppins


### PR DESCRIPTION
## Summary
- replace Material icons for professions with custom PNG assets
- add new icons to pubspec assets list

## Testing
- `dart format lib/utils/service_type_utils.dart lib/screens/welcome_page.dart lib/screens/appointments_page.dart pubspec.yaml` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d73afd0832ba71e06b11b7c2686