### PR TITLE
Replace 'Barbershop' references with 'Barber'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vogue Vault
 
-Vogue Vault is a scheduling platform for barbershops, hairdressers, nail technicians, tattoo artists, and other beauty professionals and their clients. Salon owners, barbers, stylists, nail techs, tattoo artists, and makeup artists can showcase services, manage calendars, and coordinate appointments in one place.
+Vogue Vault is a scheduling platform for barbers, hairdressers, nail technicians, tattoo artists, and other beauty professionals and their clients. Salon owners, barbers, stylists, nail techs, tattoo artists, and makeup artists can showcase services, manage calendars, and coordinate appointments in one place.
 
 ## Setup
 
@@ -44,7 +44,7 @@ flutter pub get
 
 ### Example Services
 
-- Barbershop cuts
+- Barber cuts
 - Hair styling and coloring
 - Manicures and pedicures
 - Tattoo design and application

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -68,7 +68,7 @@
   "guestNameLabel": "Guest Name",
   "guestContactLabel": "Guest Contact (optional)",
   "clientOrGuestValidation": "Please select a client or enter a guest name",
-  "serviceTypeBarber": "Barbershop",
+  "serviceTypeBarber": "Barber",
   "serviceTypeHairdresser": "Hairdresser",
   "serviceTypeNails": "Nails",
   "serviceTypeTattoo": "Tattoo Artist"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -68,7 +68,7 @@
   "guestNameLabel": "Nombre del invitado",
   "guestContactLabel": "Contacto del invitado (opcional)",
   "clientOrGuestValidation": "Selecciona un cliente o ingresa un nombre de invitado",
-  "serviceTypeBarber": "Barbería",
+  "serviceTypeBarber": "Barbero",
   "serviceTypeHairdresser": "Peluquería",
   "serviceTypeNails": "Uñas",
   "serviceTypeTattoo": "Tatuador"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -506,7 +506,7 @@ abstract class AppLocalizations {
   /// No description provided for @serviceTypeBarber.
   ///
   /// In en, this message translates to:
-  /// **'Barbershop'**
+  /// **'Barber'**
   String get serviceTypeBarber;
 
   /// No description provided for @serviceTypeHairdresser.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -213,7 +213,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clientOrGuestValidation => 'Please select a client or enter a guest name';
 
   @override
-  String get serviceTypeBarber => 'Barbershop';
+  String get serviceTypeBarber => 'Barber';
 
   @override
   String get serviceTypeHairdresser => 'Hairdresser';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -213,7 +213,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get clientOrGuestValidation => 'Selecciona un cliente o ingresa un nombre de invitado';
 
   @override
-  String get serviceTypeBarber => 'Barbería';
+  String get serviceTypeBarber => 'Barbero';
 
   @override
   String get serviceTypeHairdresser => 'Peluquería';

--- a/test/utils/service_type_utils_test.dart
+++ b/test/utils/service_type_utils_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   testWidgets('returns English labels', (tester) async {
     final context = await _pumpApp(tester, const Locale('en'));
-    expect(serviceTypeLabel(context, ServiceType.barber), 'Barbershop');
+    expect(serviceTypeLabel(context, ServiceType.barber), 'Barber');
     expect(serviceTypeLabel(context, ServiceType.hairdresser), 'Hairdresser');
     expect(serviceTypeLabel(context, ServiceType.nails), 'Nails');
     expect(serviceTypeLabel(context, ServiceType.tattoo), 'Tattoo Artist');
@@ -32,7 +32,7 @@ void main() {
 
   testWidgets('returns Spanish labels', (tester) async {
     final context = await _pumpApp(tester, const Locale('es'));
-    expect(serviceTypeLabel(context, ServiceType.barber), 'Barbería');
+    expect(serviceTypeLabel(context, ServiceType.barber), 'Barbero');
     expect(serviceTypeLabel(context, ServiceType.hairdresser), 'Peluquería');
     expect(serviceTypeLabel(context, ServiceType.nails), 'Uñas');
     expect(serviceTypeLabel(context, ServiceType.tattoo), 'Tatuador');


### PR DESCRIPTION
## Summary
- use "Barber" rather than "Barbershop" across README and localization files
- update English and Spanish service type labels and related tests

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689e3bceb6b8832b8b8f66df598bfa66