### PR TITLE
Validate email format on AuthPage

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -122,6 +122,10 @@ class _AuthPageState extends State<AuthPage> {
                       if (value == null || value.isEmpty) {
                         return AppLocalizations.of(context)!.emailRequired;
                       }
+                      final emailRegex = RegExp(r'^[^@]+@[^@]+\.[^@]+$');
+                      if (!emailRegex.hasMatch(value)) {
+                        return 'Invalid email format';
+                      }
                       return null;
                     },
                   ),

--- a/test/screens/auth_page_test.dart
+++ b/test/screens/auth_page_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/screens/auth_page.dart';
+import 'package:vogue_vault/services/auth_service.dart';
+
+class FakeAuthService extends AuthService {
+  @override
+  bool get isLoggedIn => false;
+}
+
+void main() {
+  testWidgets('invalid email shows error', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthService>.value(
+        value: FakeAuthService(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const AuthPage(),
+        ),
+      ),
+    );
+
+    final formFinder = find.byType(Form);
+    final emailField = find.byType(TextFormField).first;
+
+    await tester.enterText(emailField, 'invalid');
+    final formState = tester.state<FormState>(formFinder);
+    expect(formState.validate(), isFalse);
+    await tester.pump();
+    expect(find.text('Invalid email format'), findsOneWidget);
+  });
+
+  testWidgets('valid email passes validation', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthService>.value(
+        value: FakeAuthService(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const AuthPage(),
+        ),
+      ),
+    );
+
+    final formFinder = find.byType(Form);
+    final emailField = find.byType(TextFormField).first;
+
+    await tester.enterText(emailField, 'user@example.com');
+    final formState = tester.state<FormState>(formFinder);
+    expect(formState.validate(), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- improve email TextFormField validator to reject invalid addresses
- add widget tests for valid and invalid email entries

## Testing
- `dart format lib/screens/auth_page.dart test/screens/auth_page_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e511e3580832b96a378db0e448d9b