### PR TITLE
Sort appointments list chronologically

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -40,10 +40,12 @@ class AppointmentService extends ChangeNotifier {
 
   List<Appointment> get appointments {
     if (!_initialized) return [];
-    return _appointmentsBox.values
+    final appts = _appointmentsBox.values
         .map((m) => Appointment.fromMap(
             _withProviderId(Map<String, dynamic>.from(m))))
         .toList();
+    appts.sort((a, b) => a.dateTime.compareTo(b.dateTime));
+    return appts;
   }
 
   List<UserProfile> get users {

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -34,6 +34,30 @@ void main() {
     await Hive.deleteFromDisk();
   });
 
+  test('appointments getter returns appointments sorted by date', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    final later = Appointment(
+      id: 'a1',
+      providerId: 'p1',
+      service: ServiceType.barber,
+      dateTime: DateTime.parse('2023-01-02'),
+    );
+    final earlier = Appointment(
+      id: 'a2',
+      providerId: 'p1',
+      service: ServiceType.barber,
+      dateTime: DateTime.parse('2023-01-01'),
+    );
+
+    await service.addAppointment(later);
+    await service.addAppointment(earlier);
+
+    final appts = service.appointments;
+    expect(appts.map((a) => a.id), ['a2', 'a1']);
+  });
+
   test('legacy appointments load with default providerId', () async {
     final service = AppointmentService();
     await service.init();


### PR DESCRIPTION
## Summary
- Sort appointments by `dateTime` in `AppointmentService`
- Add unit test verifying appointments are returned in chronological order

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e55b07858832b9860faf77574d7f6