### PR TITLE
Use UUIDs for entity identifiers

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
+import 'package:uuid/uuid.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/appointment.dart';
@@ -235,8 +236,8 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ElevatedButton(
                 onPressed: () async {
                   if (!_formKey.currentState!.validate()) return;
-                  final id = widget.appointment?.id ??
-                      DateTime.now().millisecondsSinceEpoch.toString();
+                  final id =
+                      widget.appointment?.id ?? const Uuid().v4();
                   final newAppt = Appointment(
                     id: id,
                     clientId: _selectedClientId,

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_profile.dart';
@@ -318,8 +319,8 @@ class EditUserPage extends StatelessWidget {
                       return;
                     }
                     final service = context.read<AppointmentService>();
-                    final id = user?.id ??
-                        DateTime.now().millisecondsSinceEpoch.toString();
+                    final id =
+                        user?.id ?? const Uuid().v4();
                     final newUser = UserProfile(
                       id: id,
                       firstName: firstNameController.text.trim(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -898,6 +898,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: "a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   file_selector: ^1.0.3
   cryptography: ^2.7.0
   flutter_gen: ^5.9.0
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -1,14 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid/uuid.dart';
 import 'package:vogue_vault/models/appointment.dart';
 import 'package:vogue_vault/models/service_type.dart';
 
 void main() {
   group('Appointment serialization', () {
     test('toMap and fromMap produce equivalent objects', () {
+      final uuid = const Uuid();
+      final id = uuid.v4();
+      final clientId = uuid.v4();
+      final providerId = uuid.v4();
       final appointment = Appointment(
-        id: 'a1',
-        clientId: 'c1',
-        providerId: 'p1',
+        id: id,
+        clientId: clientId,
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -23,11 +28,12 @@ void main() {
     });
 
     test('supports guest clients', () {
+      final uuid = const Uuid();
       final appointment = Appointment(
-        id: 'a2',
+        id: uuid.v4(),
         guestName: 'Walk-in',
         guestContact: '555-1234',
-        providerId: 'p1',
+        providerId: uuid.v4(),
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 11, 0),
       );
@@ -40,13 +46,14 @@ void main() {
     });
 
     test('fromMap validates required data', () {
-      final missingFields = {'id': 'a1'};
+      final uuid = const Uuid();
+      final missingFields = {'id': uuid.v4()};
       expect(() => Appointment.fromMap(missingFields), throwsA(isA<TypeError>()));
 
       final invalidDate = {
-        'id': 'a1',
-        'clientId': 'c1',
-        'providerId': 'p1',
+        'id': uuid.v4(),
+        'clientId': uuid.v4(),
+        'providerId': uuid.v4(),
         'service': 'barber',
         'dateTime': 'invalid',
       };
@@ -56,17 +63,21 @@ void main() {
 
   group('Appointment equality', () {
     test('appointments with the same values are equal', () {
+      final uuid = const Uuid();
+      final id = uuid.v4();
+      final clientId = uuid.v4();
+      final providerId = uuid.v4();
       final a1 = Appointment(
-        id: 'a1',
-        clientId: 'c1',
-        providerId: 'p1',
+        id: id,
+        clientId: clientId,
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
       final a2 = Appointment(
-        id: 'a1',
-        clientId: 'c1',
-        providerId: 'p1',
+        id: id,
+        clientId: clientId,
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
@@ -76,20 +87,23 @@ void main() {
     });
 
     test('appointments with same guest values are equal', () {
+      final uuid = const Uuid();
       final dt = DateTime(2023, 9, 10, 10, 0);
+      final id = uuid.v4();
+      final providerId = uuid.v4();
       final a1 = Appointment(
-        id: 'a1',
+        id: id,
         guestName: 'Walk-in',
         guestContact: '555',
-        providerId: 'p1',
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: dt,
       );
       final a2 = Appointment(
-        id: 'a1',
+        id: id,
         guestName: 'Walk-in',
         guestContact: '555',
-        providerId: 'p1',
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: dt,
       );
@@ -98,17 +112,22 @@ void main() {
     });
 
     test('appointments with different values are not equal', () {
+      final uuid = const Uuid();
+      final id1 = uuid.v4();
+      final id2 = uuid.v4();
+      final clientId = uuid.v4();
+      final providerId = uuid.v4();
       final a1 = Appointment(
-        id: 'a1',
-        clientId: 'c1',
-        providerId: 'p1',
+        id: id1,
+        clientId: clientId,
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );
       final a2 = Appointment(
-        id: 'a2',
-        clientId: 'c1',
-        providerId: 'p1',
+        id: id2,
+        clientId: clientId,
+        providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
       );

--- a/test/models/user_profile_test.dart
+++ b/test/models/user_profile_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid/uuid.dart';
 import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/models/user_role.dart';
 import 'package:vogue_vault/models/service_type.dart';
@@ -9,8 +10,9 @@ import 'package:vogue_vault/models/service_offering.dart';
 void main() {
   group('UserProfile serialization', () {
     test('toMap and fromMap produce equivalent objects', () {
+      final uuid = const Uuid();
       final profile = UserProfile(
-        id: 'u1',
+        id: uuid.v4(),
         firstName: 'Alice',
         lastName: 'Smith',
         nickname: 'Ally',
@@ -32,7 +34,7 @@ void main() {
 
     test('handles null photoBytes and empty sets', () {
       final profile = UserProfile(
-        id: 'u2',
+        id: const Uuid().v4(),
         firstName: 'Bob',
         lastName: 'Builder',
       );
@@ -51,8 +53,10 @@ void main() {
 
   group('UserProfile equality', () {
     test('profiles with the same values are equal and hashCodes match', () {
+      final uuid = const Uuid();
+      final id = uuid.v4();
       final p1 = UserProfile(
-        id: 'u1',
+        id: id,
         firstName: 'Alice',
         lastName: 'Smith',
         nickname: 'Ally',
@@ -63,7 +67,7 @@ void main() {
         ],
       );
       final p2 = UserProfile(
-        id: 'u1',
+        id: id,
         firstName: 'Alice',
         lastName: 'Smith',
         nickname: 'Ally',
@@ -79,13 +83,14 @@ void main() {
     });
 
     test('profiles with different data are not equal', () {
+      final id = const Uuid().v4();
       final p1 = UserProfile(
-        id: 'u1',
+        id: id,
         firstName: 'Alice',
         lastName: 'Smith',
       );
       final p2 = UserProfile(
-        id: 'u1',
+        id: id,
         firstName: 'Alice',
         lastName: 'Smith',
         nickname: 'Ally',
@@ -97,8 +102,9 @@ void main() {
 
   group('UserProfile service type parsing', () {
     test('skips invalid service types in legacy services list', () {
+      final uuid = const Uuid();
       final map = {
-        'id': 'u1',
+        'id': uuid.v4(),
         'firstName': 'Alice',
         'lastName': 'Smith',
         'services': ['barber', 'unknown']
@@ -111,8 +117,9 @@ void main() {
     });
 
     test('defaults invalid offering type to first enum value', () {
+      final uuid = const Uuid();
       final map = {
-        'id': 'u1',
+        'id': uuid.v4(),
         'firstName': 'Alice',
         'lastName': 'Smith',
         'offerings': [


### PR DESCRIPTION
## Summary
- add `uuid` package
- generate IDs with `Uuid().v4()` in appointment and user editors
- update tests to create entities with UUIDs

## Testing
- `dart pub get` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e571e9cd4832bb3839e23f549d00a