### PR TITLE
Validate non-negative service price

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -259,11 +259,15 @@ class EditUserPage extends StatelessWidget {
                                                   double.tryParse(val) ?? 0);
                                         });
                                       },
-                                      validator: (val) => val == null ||
-                                              double.tryParse(val) == null
-                                          ? AppLocalizations.of(context)!
-                                              .invalidPrice
-                                          : null,
+                                      validator: (val) {
+                                        final parsed =
+                                            double.tryParse(val ?? '');
+                                        if (parsed == null || parsed < 0) {
+                                          return AppLocalizations.of(context)!
+                                              .invalidPrice;
+                                        }
+                                        return null;
+                                      },
                                     ),
                                   ),
                                   IconButton(

--- a/test/screens/edit_user_page_test.dart
+++ b/test/screens/edit_user_page_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/models/user_role.dart';
+import 'package:vogue_vault/screens/edit_user_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/role_provider.dart';
+
+class _FakeAppointmentService extends AppointmentService {
+  @override
+  List<UserProfile> get users => [];
+}
+
+void main() {
+  testWidgets('negative price shows error', (tester) async {
+    final roleProvider = RoleProvider()..selectedRole = UserRole.professional;
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
+          ChangeNotifierProvider<AppointmentService>(
+            create: (_) => _FakeAppointmentService(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const EditUserPage(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Professional'));
+    await tester.pump();
+
+    await tester.tap(find.text('Add'));
+    await tester.pump();
+
+    final priceField = find.widgetWithText(TextFormField, 'Price');
+    await tester.enterText(priceField, '-5');
+
+    final formFinder = find.byType(Form);
+    final formState = tester.state<FormState>(formFinder);
+    expect(formState.validate(), isFalse);
+    await tester.pump();
+    expect(find.text('Invalid price'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure service price validation rejects negative values
- add widget test covering negative price input

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e5991f38c832baf1f2a3258e6e66d