### PR TITLE
Load user roles after authentication and restrict role selection

### DIFF
--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -10,7 +10,6 @@ import '../models/service_type.dart';
 import '../models/service_offering.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
-import '../services/role_provider.dart';
 import '../utils/image_picking.dart';
 
 class ProfilePage extends StatefulWidget {
@@ -36,14 +35,13 @@ class _ProfilePageState extends State<ProfilePage> {
     super.initState();
     final auth = context.read<AuthService>();
     final service = context.read<AppointmentService>();
-    final roleProvider = context.read<RoleProvider>();
     _userId = auth.currentUser ?? DateTime.now().millisecondsSinceEpoch.toString();
     final user = service.getUser(_userId);
     _firstNameController.text = user?.firstName ?? '';
     _lastNameController.text = user?.lastName ?? '';
     _nicknameController = TextEditingController(text: user?.nickname ?? '');
     _photoBytes = user?.photoBytes;
-    _roles = {...(user?.roles ?? roleProvider.roles)};
+    _roles = user?.roles ?? {UserRole.customer};
     _offerings = [...(user?.offerings ?? <ServiceOffering>[])];
   }
 

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -4,13 +4,32 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_role.dart';
 import '../services/auth_service.dart';
+import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
 import 'auth_page.dart';
 import 'appointments_page.dart';
 import 'welcome_page.dart';
 
-class RoleSelectionPage extends StatelessWidget {
+class RoleSelectionPage extends StatefulWidget {
   const RoleSelectionPage({super.key});
+
+  @override
+  State<RoleSelectionPage> createState() => _RoleSelectionPageState();
+}
+
+class _RoleSelectionPageState extends State<RoleSelectionPage> {
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthService>();
+    final userId = auth.currentUser;
+    if (userId != null) {
+      final user = context.read<AppointmentService>().getUser(userId);
+      if (user != null) {
+        context.read<RoleProvider>().setRoles(user.roles);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -4,7 +4,7 @@ import '../models/user_role.dart';
 
 class RoleProvider extends ChangeNotifier {
   UserRole? _selectedRole;
-  final Set<UserRole> _roles = {UserRole.customer, UserRole.professional};
+  final Set<UserRole> _roles = {UserRole.customer};
 
   UserRole? get selectedRole => _selectedRole;
   Set<UserRole> get roles => Set.unmodifiable(_roles);


### PR DESCRIPTION
## Summary
- Default role provider to customer only
- Initialize profile roles from user or default to customer
- Fetch user roles after login and display only allowed role options

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e71edb514832b8cd5cd10190c7b41