### PR TITLE
Add user credential deletion in auth service

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -68,6 +68,7 @@ class EditUserPage extends StatelessWidget {
                     onPressed: () async {
                       try {
                         await service.deleteUser(user.id);
+                        await context.read<AuthService>().deleteUser(user.id);
                       } catch (e) {
                         if (!context.mounted) return;
                         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -120,5 +120,18 @@ class AuthService extends ChangeNotifier {
     await _box.delete(_currentUserKey);
     notifyListeners();
   }
+
+  Future<void> deleteUser(String email) async {
+    _ensureInitialized();
+    final users = _users;
+
+    if (currentUser == email) {
+      await logout();
+    }
+
+    users.remove(email);
+    await _box.put(_usersKey, users);
+    notifyListeners();
+  }
 }
 


### PR DESCRIPTION
## Summary
- add AuthService.deleteUser to remove user credentials and log out current user if deleted
- call AuthService.deleteUser when removing a user from edit page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e75862d08832b9fe204382e07b22c