### PR TITLE
Add email/password update flows and profile form

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -155,6 +155,30 @@ class AppointmentService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> renameUserId(String oldId, String newId) async {
+    _ensureInitialized();
+    final userMap = _usersBox.get(oldId);
+    if (userMap != null) {
+      await _usersBox.put(newId, userMap);
+      await _usersBox.delete(oldId);
+    }
+    for (final m in _appointmentsBox.values) {
+      final map = Map<String, dynamic>.from(m);
+      final appt = Appointment.fromMap(_withProviderId(map));
+      var updated = appt;
+      if (appt.clientId == oldId) {
+        updated = updated.copyWith(clientId: newId);
+      }
+      if (appt.providerId == oldId) {
+        updated = updated.copyWith(providerId: newId);
+      }
+      if (updated != appt) {
+        await _appointmentsBox.put(updated.id, updated.toMap());
+      }
+    }
+    notifyListeners();
+  }
+
   @override
   void dispose() {
     if (_initialized) {

--- a/test/screens/profile_page_test.dart
+++ b/test/screens/profile_page_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/screens/profile_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/auth_service.dart';
+
+class _FakeAuthService extends AuthService {
+  String? _user = 'old@example.com';
+  String? changedOld;
+  String? changedNew;
+  String? pwdEmail;
+  String? pwdOld;
+  String? pwdNew;
+
+  @override
+  String? get currentUser => _user;
+
+  @override
+  Future<void> changeEmail(String oldEmail, String newEmail) async {
+    changedOld = oldEmail;
+    changedNew = newEmail;
+    _user = newEmail;
+  }
+
+  @override
+  Future<void> changePassword(
+      String email, String oldPwd, String newPwd) async {
+    pwdEmail = email;
+    pwdOld = oldPwd;
+    pwdNew = newPwd;
+  }
+}
+
+class _FakeAppointmentService extends AppointmentService {
+  final Map<String, UserProfile> store = {
+    'old@example.com':
+        UserProfile(id: 'old@example.com', firstName: 'Old', lastName: 'User')
+  };
+  String? renameOld;
+  String? renameNew;
+
+  @override
+  UserProfile? getUser(String id) => store[id];
+
+  @override
+  Future<void> updateUser(UserProfile user) async {
+    store[user.id] = user;
+  }
+
+  @override
+  Future<void> renameUserId(String oldId, String newId) async {
+    renameOld = oldId;
+    renameNew = newId;
+    final profile = store.remove(oldId);
+    if (profile != null) {
+      store[newId] = profile.copyWith(id: newId);
+    }
+  }
+}
+
+void main() {
+  testWidgets('mismatched passwords show error', (tester) async {
+    final auth = _FakeAuthService();
+    final appt = _FakeAppointmentService();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appt),
+        ],
+        child: const MaterialApp(home: ProfilePage()),
+      ),
+    );
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Current password'), 'old');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'New password'), 'new1');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Confirm password'), 'new2');
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+    expect(find.text('Passwords do not match'), findsOneWidget);
+  });
+
+  testWidgets('saving calls changeEmail and changePassword', (tester) async {
+    final auth = _FakeAuthService();
+    final appt = _FakeAppointmentService();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appt),
+        ],
+        child: const MaterialApp(home: ProfilePage()),
+      ),
+    );
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Email'), 'new@example.com');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Current password'), 'old');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'New password'), 'new');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Confirm password'), 'new');
+
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(auth.changedOld, 'old@example.com');
+    expect(auth.changedNew, 'new@example.com');
+    expect(auth.pwdEmail, 'new@example.com');
+    expect(auth.pwdOld, 'old');
+    expect(auth.pwdNew, 'new');
+    expect(appt.renameOld, 'old@example.com');
+    expect(appt.renameNew, 'new@example.com');
+  });
+}
+

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -183,4 +183,32 @@ void main() {
     final tattooArtists = service.providersFor(ServiceType.tattoo);
     expect(tattooArtists.map((p) => p.id), [p3Id]);
   });
+
+  test('renameUserId moves profile and updates appointments', () async {
+    final service = AppointmentService();
+    await service.init();
+    final uuid = const Uuid();
+    final oldId = uuid.v4();
+    final newId = uuid.v4();
+
+    final user = UserProfile(id: oldId, firstName: 'Old', lastName: 'User');
+    await service.addUser(user);
+
+    final appt = Appointment(
+      id: uuid.v4(),
+      clientId: oldId,
+      providerId: oldId,
+      service: ServiceType.barber,
+      dateTime: DateTime.parse('2023-01-01'),
+    );
+    await service.addAppointment(appt);
+
+    await service.renameUserId(oldId, newId);
+
+    expect(service.getUser(oldId), isNull);
+    expect(service.getUser(newId), isNotNull);
+    final updatedAppt = service.getAppointment(appt.id)!;
+    expect(updatedAppt.clientId, newId);
+    expect(updatedAppt.providerId, newId);
+  });
 }


### PR DESCRIPTION
## Summary
- allow AuthService to change emails and reset passwords with salt and hash regeneration
- support user id renaming across appointments
- expose email and password editing on profile page with validation and tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e82c1e134832b9966a1f3017f2c39