### PR TITLE
Add shared AppScaffold with persistent navigation

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2,6 +2,7 @@
   "@@locale": "en",
   "appTitle": "Vogue Vault",
   "appointmentsTitle": "Appointments",
+  "homeTooltip": "Home",
   "profileTooltip": "Profile",
   "switchRoleTooltip": "Switch Role",
   "usersTooltip": "Users",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2,6 +2,7 @@
   "@@locale": "es",
   "appTitle": "Bóveda de la Moda",
   "appointmentsTitle": "Citas",
+  "homeTooltip": "Inicio",
   "profileTooltip": "Perfil",
   "switchRoleTooltip": "Cambiar rol",
   "usersTooltip": "Usuarios",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -107,6 +107,12 @@ abstract class AppLocalizations {
   /// **'Appointments'**
   String get appointmentsTitle;
 
+  /// No description provided for @homeTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Home'**
+  String get homeTooltip;
+
   /// No description provided for @profileTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appointmentsTitle => 'Appointments';
 
   @override
+  String get homeTooltip => 'Home';
+
+  @override
   String get profileTooltip => 'Profile';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appointmentsTitle => 'Citas';
 
   @override
+  String get homeTooltip => 'Inicio';
+
+  @override
   String get profileTooltip => 'Perfil';
 
   @override

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -8,9 +8,9 @@ import '../models/user_role.dart';
 import '../utils/service_type_utils.dart';
 import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
+import '../widgets/app_scaffold.dart';
 import 'edit_appointment_page.dart';
 import 'edit_user_page.dart';
-import 'profile_page.dart';
 import 'role_selection_page.dart';
 
 class AppointmentsPage extends StatelessWidget {
@@ -22,45 +22,33 @@ class AppointmentsPage extends StatelessWidget {
     final role = context.watch<RoleProvider>().selectedRole;
     final appointments = service.appointments;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.appointmentsTitle),
-        actions: [
+    return AppScaffold(
+      title: AppLocalizations.of(context)!.appointmentsTitle,
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.swap_horiz),
+          tooltip: AppLocalizations.of(context)!.switchRoleTooltip,
+          onPressed: () {
+            context.read<RoleProvider>().clearRole();
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(builder: (_) => const RoleSelectionPage()),
+              (route) => false,
+            );
+          },
+        ),
+        if (role == UserRole.professional)
           IconButton(
-            icon: const Icon(Icons.person),
-            tooltip: AppLocalizations.of(context)!.profileTooltip,
+            icon: const Icon(Icons.group),
+            tooltip: AppLocalizations.of(context)!.usersTooltip,
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => const ProfilePage()),
+                MaterialPageRoute(builder: (_) => const EditUserPage()),
               );
             },
           ),
-          IconButton(
-            icon: const Icon(Icons.swap_horiz),
-            tooltip: AppLocalizations.of(context)!.switchRoleTooltip,
-            onPressed: () {
-              context.read<RoleProvider>().clearRole();
-              Navigator.pushAndRemoveUntil(
-                context,
-                MaterialPageRoute(builder: (_) => const RoleSelectionPage()),
-                (route) => false,
-              );
-            },
-          ),
-          if (role == UserRole.professional)
-            IconButton(
-              icon: const Icon(Icons.group),
-              tooltip: AppLocalizations.of(context)!.usersTooltip,
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const EditUserPage()),
-                );
-              },
-            ),
-        ],
-      ),
+      ],
       body: appointments.isEmpty
           ? Center(
               child: Column(

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -11,6 +11,7 @@ import '../models/service_offering.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../utils/image_picking.dart';
+import '../widgets/app_scaffold.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -168,10 +169,9 @@ class _ProfilePageState extends State<ProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.profileTitle),
-      ),
+    return AppScaffold(
+      title: AppLocalizations.of(context)!.profileTitle,
+      showProfileButton: false,
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -5,9 +5,9 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 import '../models/service_type.dart';
 import '../utils/service_type_utils.dart';
 import '../services/role_provider.dart';
+import '../widgets/app_scaffold.dart';
 import 'appointments_page.dart';
 import 'provider_selection_page.dart';
-import 'profile_page.dart';
 import 'role_selection_page.dart';
 
 class WelcomePage extends StatelessWidget {
@@ -15,38 +15,24 @@ class WelcomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.welcomeTitle),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.person),
-            tooltip: AppLocalizations.of(context)!.profileTooltip,
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const ProfilePage(),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.swap_horiz),
-            tooltip: AppLocalizations.of(context)!.switchRoleTooltip,
-            onPressed: () {
-              context.read<RoleProvider>().clearRole();
-              Navigator.pushAndRemoveUntil(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const RoleSelectionPage(),
-                ),
-                (route) => false,
-              );
-            },
-          ),
-        ],
-      ),
+    return AppScaffold(
+      title: AppLocalizations.of(context)!.welcomeTitle,
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.swap_horiz),
+          tooltip: AppLocalizations.of(context)!.switchRoleTooltip,
+          onPressed: () {
+            context.read<RoleProvider>().clearRole();
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const RoleSelectionPage(),
+              ),
+              (route) => false,
+            );
+          },
+        ),
+      ],
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/widgets/app_scaffold.dart
+++ b/lib/widgets/app_scaffold.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
+import '../screens/profile_page.dart';
+import '../screens/welcome_page.dart';
+
+/// A reusable scaffold with a fixed top navigation bar containing
+/// common actions across the app.
+class AppScaffold extends StatelessWidget {
+  /// The primary content of the page.
+  final Widget body;
+
+  /// Optional title displayed in the [AppBar].
+  final String? title;
+
+  /// Additional actions to display in the [AppBar]. These will appear
+  /// before the profile button.
+  final List<Widget> actions;
+
+  /// Optional floating action button for the scaffold.
+  final Widget? floatingActionButton;
+
+  /// Whether to show the profile button. Defaults to true but can be
+  /// disabled on pages like [ProfilePage] itself.
+  final bool showProfileButton;
+
+  const AppScaffold({
+    super.key,
+    required this.body,
+    this.title,
+    this.actions = const [],
+    this.floatingActionButton,
+    this.showProfileButton = true,
+  });
+
+  void _navigateHome(BuildContext context) {
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const WelcomePage()),
+      (route) => false,
+    );
+  }
+
+  void _navigateProfile(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const ProfilePage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: title != null ? Text(title!) : null,
+        leading: IconButton(
+          icon: const Icon(Icons.home),
+          tooltip: loc.homeTooltip,
+          onPressed: () => _navigateHome(context),
+        ),
+        actions: [
+          ...actions,
+          if (showProfileButton)
+            IconButton(
+              icon: const Icon(Icons.person),
+              tooltip: loc.profileTooltip,
+              onPressed: () => _navigateProfile(context),
+            ),
+        ],
+      ),
+      body: body,
+      floatingActionButton: floatingActionButton,
+    );
+  }
+}
+

--- a/test/screens/navigation_bar_test.dart
+++ b/test/screens/navigation_bar_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/screens/appointments_page.dart';
+import 'package:vogue_vault/screens/welcome_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/role_provider.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<AppointmentService>(
+          create: (_) => AppointmentService(),
+        ),
+        ChangeNotifierProvider<RoleProvider>(
+          create: (_) => RoleProvider(),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: child,
+      ),
+    );
+  }
+
+  testWidgets('navigation bar shows on welcome and routes to profile', (tester) async {
+    await tester.pumpWidget(wrap(const WelcomePage()));
+
+    expect(find.byTooltip('Home'), findsOneWidget);
+    expect(find.byTooltip('Profile'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Profile'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Profile'), findsOneWidget);
+  });
+
+  testWidgets('home button from appointments goes to welcome', (tester) async {
+    await tester.pumpWidget(wrap(const AppointmentsPage()));
+
+    expect(find.byTooltip('Home'), findsOneWidget);
+    expect(find.byTooltip('Profile'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Home'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Welcome'), findsOneWidget);
+  });
+}
+

--- a/test/screens/profile_page_test.dart
+++ b/test/screens/profile_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
+import 'package:vogue_vault/l10n/app_localizations.dart';
 import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/screens/profile_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
@@ -72,7 +73,11 @@ void main() {
           ChangeNotifierProvider<AuthService>.value(value: auth),
           ChangeNotifierProvider<AppointmentService>.value(value: appt),
         ],
-        child: const MaterialApp(home: ProfilePage()),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ProfilePage(),
+        ),
       ),
     );
 
@@ -97,7 +102,11 @@ void main() {
           ChangeNotifierProvider<AuthService>.value(value: auth),
           ChangeNotifierProvider<AppointmentService>.value(value: appt),
         ],
-        child: const MaterialApp(home: ProfilePage()),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ProfilePage(),
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary
- add reusable `AppScaffold` widget exposing home/profile buttons and optional actions
- refactor welcome, appointments and profile pages to use `AppScaffold`
- include `homeTooltip` localization and new navigation widget tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter format lib/screens/welcome_page.dart lib/screens/appointments_page.dart lib/screens/profile_page.dart lib/widgets/app_scaffold.dart test/screens/profile_page_test.dart test/screens/navigation_bar_test.dart lib/l10n/app_en.arb lib/l10n/app_es.arb lib/l10n/app_localizations.dart lib/l10n/app_localizations_en.dart lib/l10n/app_localizations_es.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e8a6595b0832b9679c312d511f454