### PR TITLE
Simplify login and add new user flow

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -18,7 +18,6 @@ class _AuthPageState extends State<AuthPage> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
-  bool _isLogin = true;
   String? _error;
 
   @override
@@ -48,18 +47,11 @@ class _AuthPageState extends State<AuthPage> {
     );
 
     bool success = false;
-    bool isRegister = false;
     try {
-      if (_isLogin) {
-        success = await auth.login(email, password);
-        if (!success) {
-          setState(() =>
-              _error = AppLocalizations.of(context)!.invalidCredentials);
-        }
-      } else {
-        await auth.register(email, password);
-        success = true;
-        isRegister = true;
+      success = await auth.login(email, password);
+      if (!success) {
+        setState(() =>
+            _error = AppLocalizations.of(context)!.invalidCredentials);
       }
     } finally {
       if (mounted) {
@@ -68,13 +60,6 @@ class _AuthPageState extends State<AuthPage> {
     }
 
     if (success && mounted) {
-      if (isRegister) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const ProfilePage()),
-        );
-        if (!mounted) return;
-      }
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (_) => const RoleSelectionPage()),
@@ -167,17 +152,17 @@ class _AuthPageState extends State<AuthPage> {
                         borderRadius: BorderRadius.circular(30),
                       ),
                     ),
-                    child: Text(_isLogin
-                        ? AppLocalizations.of(context)!.loginButton
-                        : AppLocalizations.of(context)!.registerButton),
+                    child: Text(AppLocalizations.of(context)!.loginButton),
                   ),
                   const SizedBox(height: 12),
                   OutlinedButton(
                     onPressed: () {
-                      setState(() {
-                        _isLogin = !_isLogin;
-                        _error = null;
-                      });
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const ProfilePage(isNewUser: true),
+                        ),
+                      );
                     },
                     style: OutlinedButton.styleFrom(
                       foregroundColor: AppColors.background,
@@ -187,9 +172,8 @@ class _AuthPageState extends State<AuthPage> {
                         borderRadius: BorderRadius.circular(30),
                       ),
                     ),
-                    child: Text(_isLogin
-                        ? AppLocalizations.of(context)!.createAccount
-                        : AppLocalizations.of(context)!.haveAccountSignIn),
+                    child:
+                        Text(AppLocalizations.of(context)!.createAccount),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- Remove registration logic from auth page to make it login-only
- Introduce `isNewUser` flag in profile page to support account creation
- Redirect new users to role selection after completing profile setup

## Testing
- `dart format lib/screens/auth_page.dart lib/screens/profile_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e931bf16c832b9e41cac6dd68f289