### PR TITLE
feat: make home button optional in AppScaffold

### DIFF
--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -218,6 +218,7 @@ class _ProfilePageState extends State<ProfilePage> {
     return AppScaffold(
       title: AppLocalizations.of(context)!.profileTitle,
       showProfileButton: false,
+      showHomeButton: !widget.isNewUser,
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(

--- a/lib/widgets/app_scaffold.dart
+++ b/lib/widgets/app_scaffold.dart
@@ -23,6 +23,10 @@ class AppScaffold extends StatelessWidget {
   /// disabled on pages like [ProfilePage] itself.
   final bool showProfileButton;
 
+  /// Whether to show the home button. Defaults to true but can be
+  /// disabled on pages like onboarding screens.
+  final bool showHomeButton;
+
   const AppScaffold({
     super.key,
     required this.body,
@@ -30,6 +34,7 @@ class AppScaffold extends StatelessWidget {
     this.actions = const [],
     this.floatingActionButton,
     this.showProfileButton = true,
+    this.showHomeButton = true,
   });
 
   void _navigateHome(BuildContext context) {
@@ -53,11 +58,13 @@ class AppScaffold extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: title != null ? Text(title!) : null,
-        leading: IconButton(
-          icon: const Icon(Icons.home),
-          tooltip: loc.homeTooltip,
-          onPressed: () => _navigateHome(context),
-        ),
+        leading: showHomeButton
+            ? IconButton(
+                icon: const Icon(Icons.home),
+                tooltip: loc.homeTooltip,
+                onPressed: () => _navigateHome(context),
+              )
+            : null,
         actions: [
           ...actions,
           if (showProfileButton)

--- a/test/screens/profile_page_test.dart
+++ b/test/screens/profile_page_test.dart
@@ -130,5 +130,26 @@ void main() {
     expect(appt.renameOld, 'old@example.com');
     expect(appt.renameNew, 'new@example.com');
   });
+
+  testWidgets('new user profile hides home button', (tester) async {
+    final auth = _FakeAuthService();
+    final appt = _FakeAppointmentService();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appt),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ProfilePage(isNewUser: true),
+        ),
+      ),
+    );
+
+    expect(find.byTooltip('Home'), findsNothing);
+  });
 }
 


### PR DESCRIPTION
## Summary
- add `showHomeButton` to `AppScaffold` to allow hiding the leading home icon
- hide home button on `ProfilePage` for new users
- cover new behaviour with a widget test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e98a47a74832bace51e700592b65a