### PR TITLE
Add title text to auth page

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -89,6 +89,13 @@ class _AuthPageState extends State<AuthPage> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
+                  Text(
+                    'Vogue Vault',
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      color: AppColors.background,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
                   Image.asset('assets/images/VV_LOGO.webp', height: 120),
                   const SizedBox(height: 32),
                   TextFormField(


### PR DESCRIPTION
## Summary
- display "Vogue Vault" heading above the login page logo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ea9c247d4832ba441dd3940f1596c