### PR TITLE
Center login page title

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -91,6 +91,7 @@ class _AuthPageState extends State<AuthPage> {
                 children: [
                   Text(
                     'Vogue Vault',
+                    textAlign: TextAlign.center,
                     style: theme.textTheme.headlineMedium?.copyWith(
                       color: AppColors.background,
                       fontFamily: 'LibertinusSans',


### PR DESCRIPTION
## Summary
- Center the "Vogue Vault" title on login screen for improved visual alignment

## Testing
- `dart format lib/screens/auth_page.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb47d4208832ba00663939f1b507a