### PR TITLE
feat: refresh app color palette and theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ class MyApp extends StatelessWidget {
     final lightScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primary,
     ).copyWith(
+      primary: AppColors.primary,
       background: AppColors.background,
       secondary: AppColors.secondary,
       tertiary: AppColors.accent,
@@ -57,6 +58,7 @@ class MyApp extends StatelessWidget {
       seedColor: AppColors.primary,
       brightness: Brightness.dark,
     ).copyWith(
+      primary: AppColors.primary,
       secondary: AppColors.secondary,
       tertiary: AppColors.accent,
       background: AppColors.background,
@@ -67,6 +69,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: lightScheme,
+        primaryColor: AppColors.primary,
         scaffoldBackgroundColor: AppColors.background,
         fontFamily: 'Poppins',
         textTheme: const TextTheme(
@@ -80,6 +83,7 @@ class MyApp extends StatelessWidget {
       darkTheme: ThemeData(
         useMaterial3: true,
         colorScheme: darkScheme,
+        primaryColor: AppColors.primary,
         scaffoldBackgroundColor: AppColors.background,
         fontFamily: 'Poppins',
         textTheme: const TextTheme(

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -105,7 +105,8 @@ class _AuthPageState extends State<AuthPage> {
                     controller: _emailController,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.emailLabel,
-                      prefixIcon: const Icon(Icons.email),
+                      prefixIcon:
+                          const Icon(Icons.email, color: AppColors.primary),
                       filled: true,
                       fillColor: AppColors.background,
                       border: OutlineInputBorder(
@@ -130,7 +131,8 @@ class _AuthPageState extends State<AuthPage> {
                     obscureText: true,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.passwordLabel,
-                      prefixIcon: const Icon(Icons.lock),
+                      prefixIcon:
+                          const Icon(Icons.lock, color: AppColors.primary),
                       filled: true,
                       fillColor: AppColors.background,
                       border: OutlineInputBorder(

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 /// Centralized application color palette.
 class AppColors {
   /// Primary brand color used for key UI elements.
-  static const Color primary = Color(0xFF283593);
+  static const Color primary = Color(0xFF000000);
 
   /// Secondary complementary color for varied accents.
-  static const Color secondary = Color(0xFF00695C);
+  static const Color secondary = Color(0xFFC4A664);
 
   /// Light background color ensuring high text contrast.
-  static const Color background = Color(0xFFFDFDFD);
+  static const Color background = Color(0xFFF5F0E6);
 
   /// Accent color for highlights and interactive elements.
-  static const Color accent = Color(0xFFFFA000);
+  static const Color accent = Color(0xFFC4A664);
 }


### PR DESCRIPTION
## Summary
- update app color constants to cream, black, and gold
- refresh theme configuration to use new colors
- ensure auth page icons and gradient follow palette

## Testing
- `flutter test` *(fails: command not found)*
- `flutter run -d linux` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f21a58390832b9042ba714c200ed6