### PR TITLE
feat: use primary color in text fields

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,6 +72,16 @@ class MyApp extends StatelessWidget {
         primaryColor: AppColors.primary,
         scaffoldBackgroundColor: AppColors.background,
         fontFamily: 'Poppins',
+        inputDecorationTheme: const InputDecorationTheme(
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: AppColors.primary),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: AppColors.primary),
+          ),
+          labelStyle: TextStyle(color: AppColors.primary),
+          floatingLabelStyle: TextStyle(color: AppColors.primary),
+        ),
         textTheme: const TextTheme(
           headlineLarge: TextStyle(
             fontSize: 32,
@@ -86,6 +96,16 @@ class MyApp extends StatelessWidget {
         primaryColor: AppColors.primary,
         scaffoldBackgroundColor: AppColors.background,
         fontFamily: 'Poppins',
+        inputDecorationTheme: const InputDecorationTheme(
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: AppColors.primary),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: AppColors.primary),
+          ),
+          labelStyle: TextStyle(color: AppColors.primary),
+          floatingLabelStyle: TextStyle(color: AppColors.primary),
+        ),
         textTheme: const TextTheme(
           headlineLarge: TextStyle(
             fontSize: 32,

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -103,6 +103,9 @@ class _AuthPageState extends State<AuthPage> {
                   const SizedBox(height: 32),
                   TextFormField(
                     controller: _emailController,
+                    style:
+                        const TextStyle(color: AppColors.primary),
+                    cursorColor: AppColors.primary,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.emailLabel,
                       prefixIcon:
@@ -128,6 +131,9 @@ class _AuthPageState extends State<AuthPage> {
                   const SizedBox(height: 16),
                   TextFormField(
                     controller: _passwordController,
+                    style:
+                        const TextStyle(color: AppColors.primary),
+                    cursorColor: AppColors.primary,
                     obscureText: true,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.passwordLabel,


### PR DESCRIPTION
## Summary
- ensure login TextFormFields use primary color for text and cursor
- unify TextField decoration with InputDecorationTheme using primary color borders

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2b77a220832b8ff57cc2f3fdea7a