### PR TITLE
refactor: remove gradients for flat theme

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -71,33 +71,25 @@ class _AuthPageState extends State<AuthPage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
-      body: Container(
-        width: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [AppColors.primary, AppColors.secondary],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          ),
-        ),
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    'Vogue Vault',
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.headlineMedium?.copyWith(
-                      color: AppColors.background,
-                      fontFamily: 'LibertinusSans',
-                      fontWeight: FontWeight.w400,
-                    ),
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Vogue Vault',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: AppColors.primary,
+                    fontFamily: 'LibertinusSans',
+                    fontWeight: FontWeight.w400,
                   ),
+                ),
                   const SizedBox(height: 16),
                   Image.asset('assets/images/VV_LOGO.webp', height: 200),
                   const SizedBox(height: 32),
@@ -183,8 +175,8 @@ class _AuthPageState extends State<AuthPage> {
                       );
                     },
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: AppColors.background,
-                      side: const BorderSide(color: AppColors.background),
+                      foregroundColor: AppColors.primary,
+                      side: const BorderSide(color: AppColors.primary),
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(30),

--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -122,12 +122,7 @@ class _ServiceCard extends StatelessWidget {
       },
       child: Container(
         decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              color.withOpacity(0.05),
-              color.withOpacity(0.15),
-            ],
-          ),
+          color: color.withOpacity(0.1),
           borderRadius: BorderRadius.circular(16),
         ),
         padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- replace AuthPage's gradient background with flat AppColors.background and adjust text/button colors
- simplify WelcomePage service cards to use a solid tinted color
- ensure no remaining LinearGradient usages for consistent flat design

## Testing
- `dart format lib/screens/auth_page.dart lib/screens/welcome_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2cb68c44832b8219509d586cf13b