### PR TITLE
fix: remove stray closing paren in AuthPage

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -194,7 +194,6 @@ class _AuthPageState extends State<AuthPage> {
             ),
           ),
         ),
-      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- fix extra `),` in `AuthPage` Scaffold closure

## Testing
- `flutter build web --release --base-href /vogue_vault/` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f327797c0832baf569dc168ce38af