### PR TITLE
Specify login button colors

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -157,6 +157,8 @@ class _AuthPageState extends State<AuthPage> {
                   ElevatedButton(
                     onPressed: _submit,
                     style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: AppColors.background,
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(30),


### PR DESCRIPTION
## Summary
- set explicit background and foreground colors on login button for better contrast

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f38b58e20832b8ec015fc37bed5ec