### PR TITLE
Improve service color contrast

### DIFF
--- a/lib/screens/welcome_page.dart
+++ b/lib/screens/welcome_page.dart
@@ -122,7 +122,7 @@ class _ServiceCard extends StatelessWidget {
       },
       child: Container(
         decoration: BoxDecoration(
-          color: color.withOpacity(0.1),
+          color: color.withOpacity(0.15),
           borderRadius: BorderRadius.circular(16),
         ),
         padding: const EdgeInsets.all(16),
@@ -132,7 +132,10 @@ class _ServiceCard extends StatelessWidget {
           children: [
             visual,
             const SizedBox(height: 8),
-            Text(serviceTypeLabel(context, type)),
+            Text(
+              serviceTypeLabel(context, type),
+              style: TextStyle(color: color),
+            ),
           ],
         ),
       ),

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -6,11 +6,14 @@ class AppColors {
   static const Color primary = Color(0xFF000000);
 
   /// Secondary complementary color for varied accents.
-  static const Color secondary = Color(0xFFC4A664);
+  static const Color secondary = Color(0xFF715620);
 
   /// Light background color ensuring high text contrast.
   static const Color background = Color(0xFFF5F0E6);
 
   /// Accent color for highlights and interactive elements.
-  static const Color accent = Color(0xFFC4A664);
+  static const Color accent = Color(0xFF006064);
+
+  /// Additional highlight color for differentiating services.
+  static const Color highlight = Color(0xFF4A148C);
 }

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -53,7 +53,7 @@ Color serviceTypeColor(ServiceType type) {
     case ServiceType.nails:
       return AppColors.accent;
     case ServiceType.tattoo:
-      return AppColors.background;
+      return AppColors.highlight;
   }
   assert(false, 'Unhandled ServiceType: $type');
   throw ArgumentError('Unhandled ServiceType: $type');


### PR DESCRIPTION
## Summary
- Darken secondary and accent colors and add highlight color to meet WCAG contrast
- Map each ServiceType to a distinct high-contrast color
- Adjust service cards to use new palette while keeping text legible

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f46977bf8832b81b1b3102d613eb3