### PR TITLE
Add dark background color for dark theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,7 +61,7 @@ class MyApp extends StatelessWidget {
       primary: AppColors.primary,
       secondary: AppColors.secondary,
       tertiary: AppColors.accent,
-      background: AppColors.background,
+      background: AppColors.darkBackground,
     );
 
     return MaterialApp(
@@ -94,7 +94,7 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
         colorScheme: darkScheme,
         primaryColor: AppColors.primary,
-        scaffoldBackgroundColor: AppColors.background,
+        scaffoldBackgroundColor: AppColors.darkBackground,
         fontFamily: 'Poppins',
         inputDecorationTheme: InputDecorationTheme(
           focusedBorder: OutlineInputBorder(

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -11,6 +11,9 @@ class AppColors {
   /// Light background color ensuring high text contrast.
   static const Color background = Color(0xFFF5F0E6);
 
+  /// Dark background color for dark theme surfaces.
+  static const Color darkBackground = Color(0xFF121212);
+
   /// Accent color for highlights and interactive elements.
   static const Color accent = Color(0xFF006064);
 


### PR DESCRIPTION
## Summary
- define `darkBackground` and wire it into the dark color scheme
- apply the darker background to the dark theme scaffold
- confirm new background maintains strong contrast with text

## Testing
- ⚠️ `flutter test` (flutter: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689f533b9968832b8b8dd58353ca45fd