### PR TITLE
style: add global hint style

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,6 +81,8 @@ class MyApp extends StatelessWidget {
           ),
           labelStyle: TextStyle(color: lightScheme.onSurface),
           floatingLabelStyle: TextStyle(color: lightScheme.onSurface),
+          hintStyle:
+              TextStyle(color: lightScheme.onSurface.withOpacity(0.6)),
         ),
         textTheme: const TextTheme(
           headlineLarge: TextStyle(
@@ -105,6 +107,8 @@ class MyApp extends StatelessWidget {
           ),
           labelStyle: TextStyle(color: darkScheme.onSurface),
           floatingLabelStyle: TextStyle(color: darkScheme.onSurface),
+          hintStyle:
+              TextStyle(color: darkScheme.onSurface.withOpacity(0.6)),
         ),
         textTheme: const TextTheme(
           headlineLarge: TextStyle(


### PR DESCRIPTION
## Summary
- apply global hint style in InputDecorationTheme for light and dark themes
- remove need for per-field hint colors so hints blend with surfaces

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f60b75a70832b8054168064f41a02