### PR TITLE
feat: apply updated color palette

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,7 +52,7 @@ class MyApp extends StatelessWidget {
       primary: AppColors.primary,
       background: AppColors.background,
       secondary: AppColors.secondary,
-      tertiary: AppColors.accent,
+      tertiary: AppColors.tertiary,
     );
     final darkScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primary,
@@ -60,7 +60,7 @@ class MyApp extends StatelessWidget {
     ).copyWith(
       primary: AppColors.primary,
       secondary: AppColors.secondary,
-      tertiary: AppColors.accent,
+      tertiary: AppColors.tertiary,
       background: AppColors.darkBackground,
     );
 

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -3,20 +3,20 @@ import 'package:flutter/material.dart';
 /// Centralized application color palette.
 class AppColors {
   /// Primary brand color used for key UI elements.
-  static const Color primary = Color(0xFF000000);
+  static const Color primary = Color(0xFF0D47A1);
 
   /// Secondary complementary color for varied accents.
-  static const Color secondary = Color(0xFF715620);
+  static const Color secondary = Color(0xFFFF8F00);
+
+  /// Tertiary accent color for additional interactive elements.
+  static const Color tertiary = Color(0xFF6A1B9A);
 
   /// Light background color ensuring high text contrast.
-  static const Color background = Color(0xFFF5F0E6);
+  static const Color background = Color(0xFFFDF7F2);
 
   /// Dark background color for dark theme surfaces.
   static const Color darkBackground = Color(0xFF121212);
 
-  /// Accent color for highlights and interactive elements.
-  static const Color accent = Color(0xFF006064);
-
   /// Additional highlight color for differentiating services.
-  static const Color highlight = Color(0xFF4A148C);
+  static const Color highlight = Color(0xFFB00020);
 }

--- a/lib/utils/service_type_utils.dart
+++ b/lib/utils/service_type_utils.dart
@@ -51,7 +51,7 @@ Color serviceTypeColor(ServiceType type) {
     case ServiceType.hairdresser:
       return AppColors.secondary;
     case ServiceType.nails:
-      return AppColors.accent;
+      return AppColors.tertiary;
     case ServiceType.tattoo:
       return AppColors.highlight;
   }


### PR DESCRIPTION
## Summary
- replace AppColors palette with new primary, secondary, tertiary, background, and highlight values
- wire new palette into light and dark ColorSchemes
- update serviceTypeColor mappings to reflect palette changes

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7737c3bc832b98c49cfc5cf0da0a