### PR TITLE
Add localized invalid email format message

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -59,6 +59,7 @@
   "emailLabel": "Email",
   "passwordLabel": "Password",
   "emailRequired": "Please enter your email",
+  "invalidEmailFormat": "Invalid email format",
   "passwordRequired": "Please enter your password",
   "loginButton": "Login",
   "registerButton": "Register",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -59,6 +59,7 @@
   "emailLabel": "Correo electrónico",
   "passwordLabel": "Contraseña",
   "emailRequired": "Por favor ingresa tu correo electrónico",
+  "invalidEmailFormat": "Formato de correo electrónico inválido",
   "passwordRequired": "Por favor ingresa tu contraseña",
   "loginButton": "Ingresar",
   "registerButton": "Registrarse",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -449,6 +449,12 @@ abstract class AppLocalizations {
   /// **'Please enter your email'**
   String get emailRequired;
 
+  /// No description provided for @invalidEmailFormat.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid email format'**
+  String get invalidEmailFormat;
+
   /// No description provided for @passwordRequired.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -186,6 +186,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emailRequired => 'Please enter your email';
 
   @override
+  String get invalidEmailFormat => 'Invalid email format';
+
+  @override
   String get passwordRequired => 'Please enter your password';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -186,6 +186,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get emailRequired => 'Por favor ingresa tu correo electrónico';
 
   @override
+  String get invalidEmailFormat => 'Formato de correo electrónico inválido';
+
+  @override
   String get passwordRequired => 'Por favor ingresa tu contraseña';
 
   @override

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -117,7 +117,7 @@ class _AuthPageState extends State<AuthPage> {
                       }
                       final emailRegex = RegExp(r'^[^@]+@[^@]+\.[^@]+$');
                       if (!emailRegex.hasMatch(value)) {
-                        return 'Invalid email format';
+                        return AppLocalizations.of(context)!.invalidEmailFormat;
                       }
                       return null;
                     },


### PR DESCRIPTION
## Summary
- add `invalidEmailFormat` string to English and Spanish ARB files
- regenerate localization classes with new key
- use localized string in auth page email validation

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fbc2f585c832bba911641f43f2707