### PR TITLE
feat: add password visibility toggle

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -18,6 +18,7 @@ class _AuthPageState extends State<AuthPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   String? _error;
+  bool _showPassword = false;
 
   @override
   void initState() {
@@ -127,10 +128,20 @@ class _AuthPageState extends State<AuthPage> {
                     controller: _passwordController,
                     style: TextStyle(color: colors.onSurface),
                     cursorColor: colors.onSurface,
-                    obscureText: true,
+                    obscureText: !_showPassword,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.passwordLabel,
                       prefixIcon: Icon(Icons.lock, color: colors.onSurface),
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _showPassword
+                              ? Icons.visibility_off
+                              : Icons.visibility,
+                          color: colors.onSurface,
+                        ),
+                        onPressed: () =>
+                            setState(() => _showPassword = !_showPassword),
+                      ),
                       filled: true,
                       fillColor: colors.surface,
                       border: OutlineInputBorder(

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -33,6 +33,10 @@ class _ProfilePageState extends State<ProfilePage> {
   final _newPwdController = TextEditingController();
   final _confirmPwdController = TextEditingController();
 
+  bool _showCurrentPassword = false;
+  bool _showNewPassword = false;
+  bool _showConfirmPassword = false;
+
   Uint8List? _photoBytes;
   late String _userId;
   late Set<UserRole> _roles;
@@ -311,8 +315,15 @@ class _ProfilePageState extends State<ProfilePage> {
                           decoration: InputDecoration(
                             labelText:
                                 AppLocalizations.of(context)!.currentPasswordLabel,
+                            suffixIcon: IconButton(
+                              icon: Icon(_showCurrentPassword
+                                  ? Icons.visibility_off
+                                  : Icons.visibility),
+                              onPressed: () => setState(
+                                  () => _showCurrentPassword = !_showCurrentPassword),
+                            ),
                           ),
-                          obscureText: true,
+                          obscureText: !_showCurrentPassword,
                         ),
                         const SizedBox(height: 16),
                       ],
@@ -321,8 +332,15 @@ class _ProfilePageState extends State<ProfilePage> {
                         decoration: InputDecoration(
                           labelText:
                               AppLocalizations.of(context)!.newPasswordLabel,
+                          suffixIcon: IconButton(
+                            icon: Icon(_showNewPassword
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                            onPressed: () => setState(
+                                () => _showNewPassword = !_showNewPassword),
+                          ),
                         ),
-                        obscureText: true,
+                        obscureText: !_showNewPassword,
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
@@ -330,8 +348,15 @@ class _ProfilePageState extends State<ProfilePage> {
                         decoration: InputDecoration(
                           labelText:
                               AppLocalizations.of(context)!.confirmPasswordLabel,
+                          suffixIcon: IconButton(
+                            icon: Icon(_showConfirmPassword
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                            onPressed: () => setState(() =>
+                                _showConfirmPassword = !_showConfirmPassword),
+                          ),
                         ),
-                        obscureText: true,
+                        obscureText: !_showConfirmPassword,
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- add password visibility toggle to login form
- allow toggling password fields on profile page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc28727a8832ba44452bb4e669f58