### PR TITLE
Add locale-aware date formatting

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -21,6 +21,7 @@ class AppointmentsPage extends StatelessWidget {
     final service = context.watch<AppointmentService>();
     final role = context.watch<RoleProvider>().selectedRole;
     final appointments = service.appointments;
+    final locale = Localizations.localeOf(context).toString();
 
     return AppScaffold(
       title: AppLocalizations.of(context)!.appointmentsTitle,
@@ -95,7 +96,9 @@ class AppointmentsPage extends StatelessWidget {
                     '$clientName - ${serviceTypeLabel(context, appt.service)}',
                   ),
                   subtitle: Text(
-                    DateFormat.yMMMd().add_jm().format(appt.dateTime.toLocal()),
+                    DateFormat.yMMMd(locale)
+                        .add_jm()
+                        .format(appt.dateTime.toLocal()),
                   ),
                   onTap: role == UserRole.professional
                       ? () {

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -56,6 +56,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
     final service = context.watch<AppointmentService>();
     final clients = service.clients;
     final providers = service.providersFor(_service);
+    final locale = Localizations.localeOf(context).toString();
     if (_selectedClientId != null &&
         !clients.any((c) => c.id == _selectedClientId)) {
       _selectedClientId = null;
@@ -206,7 +207,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               const SizedBox(height: 12),
               Row(
                 children: [
-                  Text(DateFormat.yMMMd().add_jm().format(_dateTime.toLocal())),
+                  Text(DateFormat.yMMMd(locale).add_jm().format(_dateTime.toLocal())),
                   const SizedBox(width: 8),
                   TextButton(
                     onPressed: () async {

--- a/test/utils/date_format_test.dart
+++ b/test/utils/date_format_test.dart
@@ -3,9 +3,9 @@ import 'package:intl/intl.dart';
 
 void main() {
   test('formats date and time in localized style', () {
-    Intl.defaultLocale = 'en_US';
+    const locale = 'en_US';
     final dt = DateTime(2023, 9, 10, 10, 0);
-    final formatted = DateFormat.yMMMd().add_jm().format(dt);
+    final formatted = DateFormat.yMMMd(locale).add_jm().format(dt);
     expect(formatted, 'Sep 10, 2023 10:00 AM');
   });
 }


### PR DESCRIPTION
## Summary
- use current locale for date formatting in appointments and edit appointment pages
- update date format test to pass locale explicitly

## Testing
- `dart format lib/screens/appointments_page.dart lib/screens/edit_appointment_page.dart test/utils/date_format_test.dart` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689fd40a04b4832baa247b8b6a30b183