### PR TITLE
Add cannotDeleteSelfTooltip localization

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -24,6 +24,7 @@
   "priceLabel": "Price",
   "invalidPrice": "Invalid price",
   "deleteUserFailed": "Failed to delete user",
+  "cannotDeleteSelfTooltip": "Cannot delete yourself",
   "welcomeTitle": "Welcome",
   "exploreServices": "Explore our catalog",
   "getStarted": "Get Started",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -24,6 +24,7 @@
   "priceLabel": "Precio",
   "invalidPrice": "Precio inválido",
   "deleteUserFailed": "No se pudo eliminar el usuario",
+  "cannotDeleteSelfTooltip": "No puedes eliminarte a ti mismo",
   "welcomeTitle": "Bienvenido",
   "exploreServices": "Explora nuestro catálogo",
   "getStarted": "Comenzar",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -239,6 +239,12 @@ abstract class AppLocalizations {
   /// **'Failed to delete user'**
   String get deleteUserFailed;
 
+  /// No description provided for @cannotDeleteSelfTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot delete yourself'**
+  String get cannotDeleteSelfTooltip;
+
   /// No description provided for @welcomeTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -81,6 +81,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteUserFailed => 'Failed to delete user';
 
   @override
+  String get cannotDeleteSelfTooltip => 'Cannot delete yourself';
+
+  @override
   String get welcomeTitle => 'Welcome';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -81,6 +81,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteUserFailed => 'No se pudo eliminar el usuario';
 
   @override
+  String get cannotDeleteSelfTooltip => 'No puedes eliminarte a ti mismo';
+
+  @override
   String get welcomeTitle => 'Bienvenido';
 
   @override

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -58,10 +58,11 @@ class EditUserPage extends StatelessWidget {
             subtitle: Text(roleText),
             onTap: () => _showUserDialog(context, user: user),
             trailing: isSelf
-                ? const IconButton(
-                    icon: Icon(Icons.delete),
+                ? IconButton(
+                    icon: const Icon(Icons.delete),
                     onPressed: null,
-                    tooltip: 'Cannot delete yourself',
+                    tooltip: AppLocalizations.of(context)!
+                        .cannotDeleteSelfTooltip,
                   )
                 : IconButton(
                     icon: const Icon(Icons.delete),


### PR DESCRIPTION
## Summary
- add cannotDeleteSelfTooltip string to English and Spanish localization files
- update generated localization classes for new tooltip
- use localization instead of hard-coded text in edit user page

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff1dbdfe8832ba64b339ed576ac47