### PR TITLE
Use UserProfile roles as single source of truth

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,10 @@ Future<void> main() async {
           value: authService,
         ),
         ChangeNotifierProvider<RoleProvider>(
-          create: (_) => RoleProvider(),
+          create: (context) => RoleProvider(
+            context.read<AuthService>(),
+            context.read<AppointmentService>(),
+          ),
         ),
       ],
       child: const MyApp(),

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -4,7 +4,6 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_role.dart';
 import '../services/auth_service.dart';
-import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
 import 'auth_page.dart';
 import 'appointments_page.dart';
@@ -18,19 +17,6 @@ class RoleSelectionPage extends StatefulWidget {
 }
 
 class _RoleSelectionPageState extends State<RoleSelectionPage> {
-  @override
-  void initState() {
-    super.initState();
-    final auth = context.read<AuthService>();
-    final userId = auth.currentUser;
-    if (userId != null) {
-      final user = context.read<AppointmentService>().getUser(userId);
-      if (user != null) {
-        context.read<RoleProvider>().setRoles(user.roles);
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);

--- a/test/screens/edit_user_page_test.dart
+++ b/test/screens/edit_user_page_test.dart
@@ -7,23 +7,34 @@ import 'package:vogue_vault/models/user_role.dart';
 import 'package:vogue_vault/screens/edit_user_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 import 'package:vogue_vault/services/role_provider.dart';
+import 'package:vogue_vault/services/auth_service.dart';
 
 class _FakeAppointmentService extends AppointmentService {
   @override
   List<UserProfile> get users => [];
+
+  @override
+  UserProfile? getUser(String id) => null;
+}
+
+class _FakeAuthService extends AuthService {
+  @override
+  String? get currentUser => 'test';
 }
 
 void main() {
   testWidgets('negative price shows error', (tester) async {
-    final roleProvider = RoleProvider()..selectedRole = UserRole.professional;
+    final auth = _FakeAuthService();
+    final service = _FakeAppointmentService();
+    final roleProvider = RoleProvider(auth, service)
+      ..selectedRole = UserRole.professional;
 
     await tester.pumpWidget(
       MultiProvider(
         providers: [
+          ChangeNotifierProvider<AppointmentService>.value(value: service),
+          ChangeNotifierProvider<AuthService>.value(value: auth),
           ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
-          ChangeNotifierProvider<AppointmentService>(
-            create: (_) => _FakeAppointmentService(),
-          ),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/screens/navigation_bar_test.dart
+++ b/test/screens/navigation_bar_test.dart
@@ -7,16 +7,29 @@ import 'package:vogue_vault/screens/appointments_page.dart';
 import 'package:vogue_vault/screens/welcome_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 import 'package:vogue_vault/services/role_provider.dart';
+import 'package:vogue_vault/services/auth_service.dart';
+import 'package:vogue_vault/models/user_profile.dart';
+
+class _FakeAppointmentService extends AppointmentService {
+  @override
+  UserProfile? getUser(String id) => null;
+}
+
+class _FakeAuthService extends AuthService {
+  @override
+  String? get currentUser => null;
+}
 
 void main() {
   Widget wrap(Widget child) {
+    final auth = _FakeAuthService();
+    final service = _FakeAppointmentService();
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider<AppointmentService>(
-          create: (_) => AppointmentService(),
-        ),
+        ChangeNotifierProvider<AppointmentService>.value(value: service),
+        ChangeNotifierProvider<AuthService>.value(value: auth),
         ChangeNotifierProvider<RoleProvider>(
-          create: (_) => RoleProvider(),
+          create: (_) => RoleProvider(auth, service),
         ),
       ],
       child: MaterialApp(

--- a/test/services/role_provider_test.dart
+++ b/test/services/role_provider_test.dart
@@ -1,24 +1,64 @@
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:vogue_vault/services/role_provider.dart';
+import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/models/user_role.dart';
+import 'package:vogue_vault/services/role_provider.dart';
+import 'package:vogue_vault/services/auth_service.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+
+class _FakeAuthService extends AuthService {
+  String? _user;
+  void setUser(String? id) {
+    _user = id;
+    notifyListeners();
+  }
+
+  @override
+  String? get currentUser => _user;
+}
+
+class _FakeAppointmentService extends AppointmentService {
+  final Map<String, UserProfile> _users = {};
+
+  @override
+  UserProfile? getUser(String id) => _users[id];
+
+  @override
+  Future<void> addUser(UserProfile user) async {
+    _users[user.id] = user;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateUser(UserProfile user) async {
+    _users[user.id] = user;
+    notifyListeners();
+  }
+}
 
 void main() {
-  test('selectedRole is cleared when its role is removed', () {
-    final provider = RoleProvider();
+  test('role changes in user profile propagate to provider', () async {
+    final auth = _FakeAuthService();
+    final service = _FakeAppointmentService();
+    await service.addUser(UserProfile(
+      id: 'u1',
+      firstName: 'A',
+      lastName: 'B',
+      roles: {UserRole.customer},
+    ));
+    auth.setUser('u1');
+    final provider = RoleProvider(auth, service);
+
+    expect(provider.roles, {UserRole.customer});
     provider.selectedRole = UserRole.customer;
 
-    provider.setRoles({UserRole.professional});
+    await service.updateUser(UserProfile(
+      id: 'u1',
+      firstName: 'A',
+      lastName: 'B',
+      roles: {UserRole.professional},
+    ));
 
-    expect(provider.selectedRole, isNull);
-  });
-
-  test('selectedRole is cleared when removing selected role', () {
-    final provider = RoleProvider();
-    provider.selectedRole = UserRole.customer;
-
-    provider.removeRole(UserRole.customer);
-
+    expect(provider.roles, {UserRole.professional});
     expect(provider.selectedRole, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- Rework `RoleProvider` to expose roles directly from the authenticated user's profile and keep `selectedRole` in sync.
- Pass `AuthService` and `AppointmentService` into `RoleProvider` and update provider wiring.
- Simplify `RoleSelectionPage` to rely on `RoleProvider` roles.
- Update and expand tests, including a new unit test verifying role updates propagate via the provider.

## Testing
- ⚠️ `flutter test` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a094646238832bb46dccdac6b04ee1