### PR TITLE
Require explicit role selection during onboarding

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,6 +38,7 @@
   "professionalRole": "Professional",
   "cancelButton": "Cancel",
   "selectAtLeastOneService": "Please select at least one service",
+  "selectAtLeastOneRole": "Please select at least one role",
   "selectedClientRemoved": "Previously selected client was removed. Please choose another.",
   "selectedProviderRemoved": "Previously selected provider was removed or unavailable. Please choose another.",
   "editAppointmentTitle": "Edit Appointment",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -38,6 +38,7 @@
   "professionalRole": "Profesional",
   "cancelButton": "Cancelar",
   "selectAtLeastOneService": "Por favor selecciona al menos un servicio",
+  "selectAtLeastOneRole": "Por favor selecciona al menos un rol",
   "selectedClientRemoved": "El cliente seleccionado previamente fue eliminado. Por favor elige otro.",
   "selectedProviderRemoved": "El proveedor seleccionado previamente fue eliminado o no está disponible. Por favor elige otro.",
   "editAppointmentTitle": "Editar cita",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -323,6 +323,12 @@ abstract class AppLocalizations {
   /// **'Please select at least one service'**
   String get selectAtLeastOneService;
 
+  /// No description provided for @selectAtLeastOneRole.
+  ///
+  /// In en, this message translates to:
+  /// **'Please select at least one role'**
+  String get selectAtLeastOneRole;
+
   /// No description provided for @selectedClientRemoved.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -123,6 +123,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get selectAtLeastOneService => 'Please select at least one service';
 
   @override
+  String get selectAtLeastOneRole => 'Please select at least one role';
+
+  @override
   String get selectedClientRemoved => 'Previously selected client was removed. Please choose another.';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -123,6 +123,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get selectAtLeastOneService => 'Por favor selecciona al menos un servicio';
 
   @override
+  String get selectAtLeastOneRole => 'Por favor selecciona al menos un rol';
+
+  @override
   String get selectedClientRemoved => 'El cliente seleccionado previamente fue eliminado. Por favor elige otro.';
 
   @override

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -52,7 +52,7 @@ class _ProfilePageState extends State<ProfilePage> {
       _emailController = TextEditingController();
       _nicknameController = TextEditingController(text: '');
       _photoBytes = null;
-      _roles = {UserRole.customer};
+      _roles = {};
       _offerings = <ServiceOffering>[];
     } else {
       _userId =
@@ -63,7 +63,7 @@ class _ProfilePageState extends State<ProfilePage> {
       _lastNameController.text = user?.lastName ?? '';
       _nicknameController = TextEditingController(text: user?.nickname ?? '');
       _photoBytes = user?.photoBytes;
-      _roles = user?.roles ?? {UserRole.customer};
+      _roles = user?.roles ?? {};
       _offerings = [...(user?.offerings ?? <ServiceOffering>[])];
     }
   }
@@ -97,6 +97,15 @@ class _ProfilePageState extends State<ProfilePage> {
 
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
+    if (_roles.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content:
+              Text(AppLocalizations.of(context)!.selectAtLeastOneRole),
+        ),
+      );
+      return;
+    }
     if (_roles.contains(UserRole.professional) && _offerings.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -8,6 +8,7 @@ import '../services/role_provider.dart';
 import 'auth_page.dart';
 import 'appointments_page.dart';
 import 'welcome_page.dart';
+import 'profile_page.dart';
 
 class RoleSelectionPage extends StatefulWidget {
   const RoleSelectionPage({super.key});
@@ -31,6 +32,50 @@ class _RoleSelectionPageState extends State<RoleSelectionPage> {
         );
       });
       return const SizedBox.shrink();
+    }
+
+    if (roles.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(
+          title: Text(AppLocalizations.of(context)!.selectRoleTitle),
+          actions: [
+            IconButton(
+              onPressed: () {
+                context.read<AuthService>().logout();
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AuthPage()),
+                );
+              },
+              icon: const Icon(Icons.logout),
+              tooltip: AppLocalizations.of(context)!.logoutTooltip,
+            ),
+          ],
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(AppLocalizations.of(context)!.selectAtLeastOneRole),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const ProfilePage(),
+                      ),
+                    );
+                  },
+                  child: Text(AppLocalizations.of(context)!.profileTitle),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
     }
 
     return Scaffold(

--- a/lib/services/role_provider.dart
+++ b/lib/services/role_provider.dart
@@ -18,11 +18,11 @@ class RoleProvider extends ChangeNotifier {
   UserRole? _selectedRole;
 
   /// The set of roles available for the current user. Falls back to
-  /// `[UserRole.customer]` when no user is logged in or found.
+  /// an empty set when no user is logged in or found.
   Set<UserRole> get roles {
     final userId = _auth.currentUser;
-    if (userId == null) return {UserRole.customer};
-    return _appointments.getUser(userId)?.roles ?? {UserRole.customer};
+    if (userId == null) return {};
+    return _appointments.getUser(userId)?.roles ?? {};
   }
 
   UserRole? get selectedRole => _selectedRole;

--- a/test/services/role_provider_test.dart
+++ b/test/services/role_provider_test.dart
@@ -36,6 +36,14 @@ class _FakeAppointmentService extends AppointmentService {
 }
 
 void main() {
+  test('returns empty set when no user logged in', () {
+    final auth = _FakeAuthService();
+    final service = _FakeAppointmentService();
+    final provider = RoleProvider(auth, service);
+
+    expect(provider.roles, isEmpty);
+  });
+
   test('role changes in user profile propagate to provider', () async {
     final auth = _FakeAuthService();
     final service = _FakeAppointmentService();


### PR DESCRIPTION
## Summary
- Avoid defaulting to the customer role; role provider returns an empty role set until roles are defined
- Remove automatic customer assignment in profile setup and require at least one role before saving
- Handle users with no roles by prompting them in role selection to update their profile
- Add localization and tests for explicit role selection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09f2d07fc832bb15c7314722051cc