### PR TITLE
Use role mapping for dynamic buttons

### DIFF
--- a/lib/models/user_role.dart
+++ b/lib/models/user_role.dart
@@ -5,4 +5,7 @@ enum UserRole {
 
   /// A professional offering services.
   professional,
+
+  /// An administrator managing the platform.
+  admin,
 }

--- a/lib/screens/role_selection_page.dart
+++ b/lib/screens/role_selection_page.dart
@@ -10,6 +10,14 @@ import 'appointments_page.dart';
 import 'welcome_page.dart';
 import 'profile_page.dart';
 
+/// Maps each [UserRole] to the page that should be displayed when that role is
+/// selected. Tests may extend this map to verify new roles without modifying
+/// the widget implementation.
+final Map<UserRole, WidgetBuilder> rolePages = {
+  UserRole.customer: (_) => const WelcomePage(),
+  UserRole.professional: (_) => const AppointmentsPage(),
+};
+
 class RoleSelectionPage extends StatefulWidget {
   const RoleSelectionPage({super.key});
 
@@ -18,6 +26,37 @@ class RoleSelectionPage extends StatefulWidget {
 }
 
 class _RoleSelectionPageState extends State<RoleSelectionPage> {
+  List<Widget> _buildRoleButtons(BuildContext context, Set<UserRole> roles) {
+    final loc = AppLocalizations.of(context)!;
+    final labels = {
+      UserRole.customer: loc.customerRole,
+      UserRole.professional: loc.professionalRole,
+    };
+    final available = roles.where(rolePages.containsKey).toList();
+    final widgets = <Widget>[];
+    for (var i = 0; i < available.length; i++) {
+      final role = available[i];
+      widgets.add(
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: () {
+              context.read<RoleProvider>().selectedRole = role;
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: rolePages[role]!),
+              );
+            },
+            child: Text(labels[role] ?? role.name),
+          ),
+        ),
+      );
+      if (i < available.length - 1) {
+        widgets.add(const SizedBox(height: 16));
+      }
+    }
+    return widgets;
+  }
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -106,40 +145,7 @@ class _RoleSelectionPageState extends State<RoleSelectionPage> {
                 style: theme.textTheme.titleLarge,
               ),
               const SizedBox(height: 24),
-              if (roles.contains(UserRole.customer))
-                SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
-                    onPressed: () {
-                      context.read<RoleProvider>().selectedRole = UserRole.customer;
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => const WelcomePage(),
-                        ),
-                      );
-                    },
-                    child: Text(AppLocalizations.of(context)!.customerRole),
-                  ),
-                ),
-              if (roles.contains(UserRole.customer))
-                const SizedBox(height: 16),
-              if (roles.contains(UserRole.professional))
-                SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
-                    onPressed: () {
-                      context.read<RoleProvider>().selectedRole = UserRole.professional;
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => const AppointmentsPage(),
-                        ),
-                      );
-                    },
-                    child: Text(AppLocalizations.of(context)!.professionalRole),
-                  ),
-                ),
+              ..._buildRoleButtons(context, roles),
             ],
           ),
         ),

--- a/test/screens/role_selection_page_test.dart
+++ b/test/screens/role_selection_page_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/models/user_role.dart';
+import 'package:vogue_vault/screens/role_selection_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/auth_service.dart';
+import 'package:vogue_vault/services/role_provider.dart';
+
+class _FakeAuthService extends AuthService {
+  @override
+  bool get isLoggedIn => true;
+
+  @override
+  String? get currentUser => 'u1';
+}
+
+class _FakeAppointmentService extends AppointmentService {
+  _FakeAppointmentService(this._user);
+
+  final UserProfile _user;
+
+  @override
+  List<UserProfile> get users => [_user];
+
+  @override
+  UserProfile? getUser(String id) => id == _user.id ? _user : null;
+}
+
+void main() {
+  testWidgets('shows buttons for available roles', (tester) async {
+    final user = UserProfile(
+      id: 'u1',
+      firstName: 'A',
+      lastName: 'B',
+      roles: {UserRole.customer, UserRole.professional},
+    );
+    final auth = _FakeAuthService();
+    final appointment = _FakeAppointmentService(user);
+    final roleProvider = RoleProvider(auth, appointment);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appointment),
+          ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: RoleSelectionPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Customer'), findsOneWidget);
+    expect(find.text('Professional'), findsOneWidget);
+  });
+
+  testWidgets('new role appears automatically', (tester) async {
+    final user = UserProfile(
+      id: 'u1',
+      firstName: 'A',
+      lastName: 'B',
+      roles: {UserRole.admin},
+    );
+    final auth = _FakeAuthService();
+    final appointment = _FakeAppointmentService(user);
+    final roleProvider = RoleProvider(auth, appointment);
+
+    final original = Map<UserRole, WidgetBuilder>.from(rolePages);
+    rolePages[UserRole.admin] = (_) => const SizedBox();
+    addTearDown(() {
+      rolePages
+        ..clear()
+        ..addAll(original);
+    });
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appointment),
+          ChangeNotifierProvider<RoleProvider>.value(value: roleProvider),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: RoleSelectionPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('admin'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Build role buttons dynamically using a role-to-page map
- Introduce an admin role and support extensible button generation
- Test that adding a new role automatically shows a new button

## Testing
- ⚠️ `flutter test` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a0af683c832b97b418e80d4acdd0