### PR TITLE
refactor: share role and service offering widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ lib/
   models/        # data classes such as Appointment and Client
   services/      # service layer and persistence
   screens/       # UI pages
+  widgets/       # shared UI components (e.g., RoleSelector, ServiceOfferingEditor)
   utils/         # helpers and constants
   main.dart      # app entry point
 ```

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -7,8 +7,9 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_profile.dart';
 import '../models/user_role.dart';
-import '../models/service_type.dart';
 import '../models/service_offering.dart';
+import '../widgets/role_selector.dart';
+import '../widgets/service_offering_editor.dart';
 import '../services/appointment_service.dart';
 import '../services/role_provider.dart';
 import '../services/auth_service.dart';
@@ -175,140 +176,26 @@ class EditUserPage extends StatelessWidget {
                             labelText:
                                 AppLocalizations.of(context)!.nicknameLabel),
                       ),
-                      CheckboxListTile(
-                        value: roles.contains(UserRole.customer),
-                        title: Text(AppLocalizations.of(context)!.customerRole),
-                        onChanged: (value) {
+                      RoleSelector(
+                        selected: roles,
+                        onChanged: (selection) {
                           setState(() {
-                            if (value == true) {
-                              roles.add(UserRole.customer);
-                            } else {
-                              roles.remove(UserRole.customer);
-                            }
-                          });
-                        },
-                      ),
-                      CheckboxListTile(
-                        value: roles.contains(UserRole.professional),
-                        title:
-                            Text(AppLocalizations.of(context)!.professionalRole),
-                        onChanged: (value) {
-                          setState(() {
-                            if (value == true) {
-                              roles.add(UserRole.professional);
-                            } else {
-                              roles.remove(UserRole.professional);
-                            }
+                            roles
+                              ..clear()
+                              ..addAll(selection);
                           });
                         },
                       ),
                       if (roles.contains(UserRole.professional))
-                        Column(
-                          children: [
-                            for (int i = 0; i < offerings.length; i++)
-                              Row(
-                                children: [
-                                  Expanded(
-                                    child:
-                                        DropdownButtonFormField<ServiceType>(
-                                      value: offerings[i].type,
-                                      decoration: InputDecoration(
-                                          labelText: AppLocalizations.of(
-                                                  context)!
-                                              .serviceLabel),
-                                      items: ServiceType.values
-                                          .map(
-                                            (s) => DropdownMenuItem<
-                                                ServiceType>(
-                                              value: s,
-                                              child: Text(s.name),
-                                            ),
-                                          )
-                                          .toList(),
-                                      onChanged: (value) {
-                                        if (value == null) return;
-                                        setState(() {
-                                          offerings[i] =
-                                              offerings[i].copyWith(
-                                                  type: value);
-                                        });
-                                      },
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Expanded(
-                                    child: TextFormField(
-                                      initialValue: offerings[i].name,
-                                      decoration: InputDecoration(
-                                          labelText: AppLocalizations.of(
-                                                  context)!
-                                              .nameLabel),
-                                      onChanged: (val) {
-                                        setState(() {
-                                          offerings[i] =
-                                              offerings[i].copyWith(
-                                                  name: val);
-                                        });
-                                      },
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Expanded(
-                                    child: TextFormField(
-                                      initialValue:
-                                          offerings[i].price.toString(),
-                                      decoration: InputDecoration(
-                                          labelText:
-                                              AppLocalizations.of(context)!
-                                                  .priceLabel),
-                                      keyboardType:
-                                          const TextInputType.numberWithOptions(
-                                              decimal: true),
-                                      onChanged: (val) {
-                                        setState(() {
-                                          offerings[i] = offerings[i].copyWith(
-                                              price:
-                                                  double.tryParse(val) ?? 0);
-                                        });
-                                      },
-                                      validator: (val) {
-                                        final parsed =
-                                            double.tryParse(val ?? '');
-                                        if (parsed == null || parsed < 0) {
-                                          return AppLocalizations.of(context)!
-                                              .invalidPrice;
-                                        }
-                                        return null;
-                                      },
-                                    ),
-                                  ),
-                                  IconButton(
-                                    icon: const Icon(Icons.remove_circle),
-                                    onPressed: () {
-                                      setState(() {
-                                        offerings.removeAt(i);
-                                      });
-                                    },
-                                  ),
-                                ],
-                              ),
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: TextButton.icon(
-                                onPressed: () {
-                                  setState(() {
-                                    offerings.add(ServiceOffering(
-                                        type: ServiceType.values.first,
-                                        name: '',
-                                        price: 0));
-                                  });
-                                },
-                                icon: const Icon(Icons.add),
-                                label: Text(
-                                    AppLocalizations.of(context)!.addButton),
-                              ),
-                            ),
-                          ],
+                        ServiceOfferingEditor(
+                          offerings: offerings,
+                          onChanged: (list) {
+                            setState(() {
+                              offerings
+                                ..clear()
+                                ..addAll(list);
+                            });
+                          },
                         ),
                     ],
                   ),

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -6,8 +6,9 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_profile.dart';
 import '../models/user_role.dart';
-import '../models/service_type.dart';
 import '../models/service_offering.dart';
+import '../widgets/role_selector.dart';
+import '../widgets/service_offering_editor.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../utils/image_picking.dart';
@@ -225,16 +226,6 @@ class _ProfilePageState extends State<ProfilePage> {
     return (firstInitial + lastInitial).toUpperCase();
   }
 
-  String _roleLabel(UserRole role) {
-    final l10n = AppLocalizations.of(context)!;
-    switch (role) {
-      case UserRole.customer:
-        return l10n.customerRole;
-      case UserRole.professional:
-        return l10n.professionalRole;
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return AppScaffold(
@@ -375,14 +366,9 @@ class _ProfilePageState extends State<ProfilePage> {
               Text(AppLocalizations.of(context)!.rolesTitle,
                   style: Theme.of(context).textTheme.titleMedium),
               const SizedBox(height: 8),
-              SegmentedButton<UserRole>(
-                segments: UserRole.values
-                    .map((role) => ButtonSegment(
-                        value: role, label: Text(_roleLabel(role))))
-                    .toList(),
-                multiSelectionEnabled: true,
+              RoleSelector(
                 selected: _roles,
-                onSelectionChanged: (selection) {
+                onChanged: (selection) {
                   setState(() => _roles = selection);
                 },
               ),
@@ -391,98 +377,11 @@ class _ProfilePageState extends State<ProfilePage> {
                 Text(AppLocalizations.of(context)!.servicesTitle,
                     style: Theme.of(context).textTheme.titleMedium),
                 const SizedBox(height: 8),
-                Column(
-                  children: [
-                    for (int i = 0; i < _offerings.length; i++)
-                      Row(
-                        children: [
-                          Expanded(
-                            child: DropdownButtonFormField<ServiceType>(
-                              value: _offerings[i].type,
-                              decoration: InputDecoration(
-                                  labelText: AppLocalizations.of(context)!
-                                      .serviceLabel),
-                              items: ServiceType.values
-                                  .map(
-                                    (s) => DropdownMenuItem<ServiceType>(
-                                      value: s,
-                                      child: Text(s.name),
-                                    ),
-                                  )
-                                  .toList(),
-                              onChanged: (value) {
-                                if (value == null) return;
-                                setState(() {
-                                  _offerings[i] =
-                                      _offerings[i].copyWith(type: value);
-                                });
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: TextFormField(
-                              initialValue: _offerings[i].name,
-                              decoration: InputDecoration(
-                                  labelText: AppLocalizations.of(context)!
-                                      .nameLabel),
-                              onChanged: (val) {
-                                setState(() {
-                                  _offerings[i] =
-                                      _offerings[i].copyWith(name: val);
-                                });
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: TextFormField(
-                              initialValue: _offerings[i].price.toString(),
-                              decoration: InputDecoration(
-                                  labelText:
-                                      AppLocalizations.of(context)!.priceLabel),
-                              keyboardType:
-                                  const TextInputType.numberWithOptions(
-                                      decimal: true),
-                              onChanged: (val) {
-                                setState(() {
-                                  _offerings[i] = _offerings[i].copyWith(
-                                      price: double.tryParse(val) ?? 0);
-                                });
-                              },
-                              validator: (val) => val == null ||
-                                      double.tryParse(val) == null
-                                  ? AppLocalizations.of(context)!.invalidPrice
-                                  : null,
-                            ),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.remove_circle),
-                            onPressed: () {
-                              setState(() {
-                                _offerings.removeAt(i);
-                              });
-                            },
-                          ),
-                        ],
-                      ),
-                    Align(
-                      alignment: Alignment.centerLeft,
-                      child: TextButton.icon(
-                        onPressed: () {
-                          setState(() {
-                            _offerings.add(ServiceOffering(
-                                type: ServiceType.values.first,
-                                name: '',
-                                price: 0));
-                          });
-                        },
-                        icon: const Icon(Icons.add),
-                        label:
-                            Text(AppLocalizations.of(context)!.addButton),
-                      ),
-                    ),
-                  ],
+                ServiceOfferingEditor(
+                  offerings: _offerings,
+                  onChanged: (list) {
+                    setState(() => _offerings = list);
+                  },
                 ),
                 const SizedBox(height: 24),
               ],

--- a/lib/widgets/role_selector.dart
+++ b/lib/widgets/role_selector.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import '../models/user_role.dart';
+import '../l10n/app_localizations.dart';
+
+/// A reusable selector for choosing one or more [UserRole] values.
+///
+/// Displays roles using a consistent [SegmentedButton] control and notifies
+/// callers when the selection changes.
+class RoleSelector extends StatelessWidget {
+  /// Currently selected roles.
+  final Set<UserRole> selected;
+
+  /// Callback invoked when the selection changes.
+  final ValueChanged<Set<UserRole>> onChanged;
+
+  const RoleSelector({
+    super.key,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  String _label(AppLocalizations l10n, UserRole role) {
+    switch (role) {
+      case UserRole.customer:
+        return l10n.customerRole;
+      case UserRole.professional:
+        return l10n.professionalRole;
+      default:
+        return role.name;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return SegmentedButton<UserRole>(
+      segments: UserRole.values
+          .map((role) => ButtonSegment<UserRole>(
+                value: role,
+                label: Text(_label(l10n, role)),
+              ))
+          .toList(),
+      multiSelectionEnabled: true,
+      selected: selected,
+      onSelectionChanged: onChanged,
+    );
+  }
+}
+

--- a/lib/widgets/service_offering_editor.dart
+++ b/lib/widgets/service_offering_editor.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/service_offering.dart';
+import '../models/service_type.dart';
+
+/// Editor widget for managing a list of [ServiceOffering] items.
+///
+/// Provides fields for selecting the service type, name and price along with
+/// controls to add or remove offerings. Changes are reported via [onChanged].
+class ServiceOfferingEditor extends StatefulWidget {
+  /// Current offerings to display.
+  final List<ServiceOffering> offerings;
+
+  /// Callback invoked when the offerings change.
+  final ValueChanged<List<ServiceOffering>> onChanged;
+
+  const ServiceOfferingEditor({
+    super.key,
+    required this.offerings,
+    required this.onChanged,
+  });
+
+  @override
+  State<ServiceOfferingEditor> createState() => _ServiceOfferingEditorState();
+}
+
+class _ServiceOfferingEditorState extends State<ServiceOfferingEditor> {
+  late List<ServiceOffering> _offerings;
+
+  @override
+  void initState() {
+    super.initState();
+    _offerings = [...widget.offerings];
+  }
+
+  @override
+  void didUpdateWidget(covariant ServiceOfferingEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.offerings != widget.offerings) {
+      _offerings = [...widget.offerings];
+    }
+  }
+
+  void _notify() => widget.onChanged(List.unmodifiable(_offerings));
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Column(
+      children: [
+        for (int i = 0; i < _offerings.length; i++)
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<ServiceType>(
+                  value: _offerings[i].type,
+                  decoration:
+                      InputDecoration(labelText: l10n.serviceLabel),
+                  items: ServiceType.values
+                      .map(
+                        (s) => DropdownMenuItem<ServiceType>(
+                          value: s,
+                          child: Text(s.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setState(() {
+                      _offerings[i] = _offerings[i].copyWith(type: value);
+                    });
+                    _notify();
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextFormField(
+                  initialValue: _offerings[i].name,
+                  decoration: InputDecoration(labelText: l10n.nameLabel),
+                  onChanged: (val) {
+                    setState(() {
+                      _offerings[i] = _offerings[i].copyWith(name: val);
+                    });
+                    _notify();
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextFormField(
+                  initialValue: _offerings[i].price.toString(),
+                  decoration: InputDecoration(labelText: l10n.priceLabel),
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  onChanged: (val) {
+                    setState(() {
+                      _offerings[i] = _offerings[i]
+                          .copyWith(price: double.tryParse(val) ?? 0);
+                    });
+                    _notify();
+                  },
+                  validator: (val) {
+                    final parsed = double.tryParse(val ?? '');
+                    if (parsed == null || parsed < 0) {
+                      return l10n.invalidPrice;
+                    }
+                    return null;
+                  },
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.remove_circle),
+                onPressed: () {
+                  setState(() {
+                    _offerings.removeAt(i);
+                  });
+                  _notify();
+                },
+              ),
+            ],
+          ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: () {
+              setState(() {
+                _offerings.add(ServiceOffering(
+                    type: ServiceType.values.first, name: '', price: 0));
+              });
+              _notify();
+            },
+            icon: const Icon(Icons.add),
+            label: Text(l10n.addButton),
+          ),
+        ),
+      ],
+    );
+  }
+}
+

--- a/test/widgets/role_selector_test.dart
+++ b/test/widgets/role_selector_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/user_role.dart';
+import 'package:vogue_vault/widgets/role_selector.dart';
+
+void main() {
+  testWidgets('selecting a role triggers callback', (tester) async {
+    Set<UserRole>? selection;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: RoleSelector(
+          selected: const {},
+          onChanged: (roles) => selection = roles,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Professional'));
+    await tester.pump();
+
+    expect(selection, {UserRole.professional});
+  });
+}

--- a/test/widgets/service_offering_editor_test.dart
+++ b/test/widgets/service_offering_editor_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/service_offering.dart';
+import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/widgets/service_offering_editor.dart';
+
+void main() {
+  testWidgets('negative price shows error', (tester) async {
+    var offerings = [
+      ServiceOffering(type: ServiceType.values.first, name: '', price: 0),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Form(
+          child: ServiceOfferingEditor(
+            offerings: offerings,
+            onChanged: (list) => offerings = list,
+          ),
+        ),
+      ),
+    );
+
+    final priceField = find.widgetWithText(TextFormField, 'Price');
+    await tester.enterText(priceField, '-5');
+
+    final formState = tester.state<FormState>(find.byType(Form));
+    expect(formState.validate(), isFalse);
+    await tester.pump();
+    expect(find.text('Invalid price'), findsOneWidget);
+  });
+
+  testWidgets('add button adds offering', (tester) async {
+    var offerings = <ServiceOffering>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: ServiceOfferingEditor(
+          offerings: offerings,
+          onChanged: (list) => offerings = list,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Add'));
+    await tester.pump();
+
+    expect(offerings.length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable RoleSelector widget for consistent role selection
- factor service offering editor into shared widget
- update profile and user editor pages to use new widgets
- document widgets and add focused tests

## Testing
- `dart format .` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a258f028832ba395b3a20e22b517