### PR TITLE
Remove service offering editor from user dialog

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -7,11 +7,10 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/user_profile.dart';
 import '../models/user_role.dart';
-import '../models/service_offering.dart';
-import '../widgets/service_offering_editor.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../utils/image_picking.dart';
+import 'profile_page.dart';
 
 class EditUserPage extends StatelessWidget {
   const EditUserPage({super.key});
@@ -90,7 +89,6 @@ class EditUserPage extends StatelessWidget {
         TextEditingController(text: user?.nickname ?? '');
     final formKey = GlobalKey<FormState>();
     Uint8List? photoBytes = user?.photoBytes;
-    final offerings = <ServiceOffering>[...user?.offerings ?? []];
 
     try {
       await showDialog(
@@ -162,15 +160,20 @@ class EditUserPage extends StatelessWidget {
                             labelText:
                                 AppLocalizations.of(context)!.nicknameLabel),
                       ),
-                      ServiceOfferingEditor(
-                        offerings: offerings,
-                        onChanged: (list) {
-                          setState(() {
-                            offerings
-                              ..clear()
-                              ..addAll(list);
-                          });
-                        },
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton(
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => const ProfilePage(),
+                              ),
+                            );
+                          },
+                          child: Text(
+                            AppLocalizations.of(context)!.servicesTitle,
+                          ),
+                        ),
                       ),
                     ],
                   ),
@@ -186,15 +189,6 @@ class EditUserPage extends StatelessWidget {
                     if (!formKey.currentState!.validate()) {
                       return;
                     }
-                    if (offerings.isEmpty) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(AppLocalizations.of(context)!
-                              .selectAtLeastOneService),
-                        ),
-                      );
-                      return;
-                    }
                     final service = context.read<AppointmentService>();
                     final id =
                         user?.id ?? const Uuid().v4();
@@ -207,7 +201,7 @@ class EditUserPage extends StatelessWidget {
                           : nicknameController.text.trim(),
                       photoBytes: photoBytes,
                       roles: const {UserRole.professional},
-                      offerings: offerings,
+                      offerings: user?.offerings,
                     );
                     if (user == null) {
                       await service.addUser(newUser);

--- a/test/screens/edit_user_page_test.dart
+++ b/test/screens/edit_user_page_test.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
-import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/screens/edit_user_page.dart';
+import 'package:vogue_vault/screens/profile_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 import 'package:vogue_vault/services/auth_service.dart';
+import 'package:vogue_vault/models/user_profile.dart';
 
 class _FakeAppointmentService extends AppointmentService {
   @override
@@ -21,7 +22,7 @@ class _FakeAuthService extends AuthService {
 }
 
 void main() {
-  testWidgets('negative price shows error', (tester) async {
+  testWidgets('services link navigates to profile page', (tester) async {
     final auth = _FakeAuthService();
     final service = _FakeAppointmentService();
 
@@ -42,16 +43,11 @@ void main() {
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Add'));
-    await tester.pump();
+    expect(find.text('Services'), findsOneWidget);
 
-    final priceField = find.widgetWithText(TextFormField, 'Price');
-    await tester.enterText(priceField, '-5');
+    await tester.tap(find.text('Services'));
+    await tester.pumpAndSettle();
 
-    final formFinder = find.byType(Form);
-    final formState = tester.state<FormState>(formFinder);
-    expect(formState.validate(), isFalse);
-    await tester.pump();
-    expect(find.text('Invalid price'), findsOneWidget);
+    expect(find.byType(ProfilePage), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Drop ServiceOfferingEditor and offerings validation from the user edit dialog
- Add link to ProfilePage for managing services separately
- Update EditUserPage test to reflect new navigation

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ac82676ff8832b80c2e0f37a0ab26a