### PR TITLE
feat: add manage services page

### DIFF
--- a/lib/screens/manage_services_page.dart
+++ b/lib/screens/manage_services_page.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/service_offering.dart';
+import '../services/appointment_service.dart';
+import '../services/auth_service.dart';
+import '../widgets/app_scaffold.dart';
+import '../widgets/service_offering_editor.dart';
+
+/// Page allowing professionals to manage their service offerings.
+class ManageServicesPage extends StatefulWidget {
+  const ManageServicesPage({super.key});
+
+  @override
+  State<ManageServicesPage> createState() => _ManageServicesPageState();
+}
+
+class _ManageServicesPageState extends State<ManageServicesPage> {
+  late List<ServiceOffering> _offerings;
+  late String _userId;
+
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthService>();
+    final service = context.read<AppointmentService>();
+    _userId = auth.currentUser ?? '';
+    final user = service.getUser(_userId);
+    _offerings = [...(user?.offerings ?? <ServiceOffering>[])];
+  }
+
+  Future<void> _save() async {
+    final service = context.read<AppointmentService>();
+    final user = service.getUser(_userId);
+    if (user != null) {
+      await service.updateUser(user.copyWith(offerings: _offerings));
+    }
+    if (mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return AppScaffold(
+      title: l10n.servicesTitle,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            ServiceOfferingEditor(
+              offerings: _offerings,
+              onChanged: (list) => setState(() => _offerings = list),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _save,
+                child: Text(l10n.saveButton),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -7,12 +7,12 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 import '../models/user_profile.dart';
 import '../models/user_role.dart';
 import '../models/service_offering.dart';
-import '../widgets/service_offering_editor.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../utils/image_picking.dart';
 import '../widgets/app_scaffold.dart';
 import 'appointments_page.dart';
+import 'manage_services_page.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key, this.isNewUser = false});
@@ -368,15 +368,21 @@ class _ProfilePageState extends State<ProfilePage> {
               ),
               const SizedBox(height: 24),
               if (!widget.isNewUser) ...[
-                Text(
-                  AppLocalizations.of(context)!.servicesTitle,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                ServiceOfferingEditor(
-                  offerings: _offerings,
-                  onChanged: (list) {
-                    setState(() => _offerings = list);
+                ListTile(
+                  title: Text(AppLocalizations.of(context)!.servicesTitle),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () async {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const ManageServicesPage(),
+                      ),
+                    );
+                    final service = context.read<AppointmentService>();
+                    setState(() {
+                      _offerings =
+                          [...?service.getUser(_userId)?.offerings];
+                    });
                   },
                 ),
                 const SizedBox(height: 24),

--- a/test/screens/manage_services_page_test.dart
+++ b/test/screens/manage_services_page_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/screens/manage_services_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/auth_service.dart';
+
+class _FakeAuthService extends AuthService {
+  @override
+  String? get currentUser => 'test@example.com';
+}
+
+class _FakeAppointmentService extends AppointmentService {
+  UserProfile profile = UserProfile(
+    id: 'test@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+    offerings: const [],
+  );
+  UserProfile? updated;
+
+  @override
+  UserProfile? getUser(String id) => id == profile.id ? profile : null;
+
+  @override
+  Future<void> updateUser(UserProfile user) async {
+    updated = user;
+    profile = user;
+  }
+}
+
+void main() {
+  testWidgets('saves updated offerings through service', (tester) async {
+    final auth = _FakeAuthService();
+    final appt = _FakeAppointmentService();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appt),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ManageServicesPage(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Add'));
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(appt.updated, isNotNull);
+    expect(appt.updated!.offerings, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add ManageServicesPage for CRUD on professional offerings
- link manage services from profile page
- ensure service updates persist via AppointmentService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8547c2ec832bbaa60176a98109a9