### PR TITLE
Add widget coverage for managing optional services

### DIFF
--- a/test/screens/auth_page_test.dart
+++ b/test/screens/auth_page_test.dart
@@ -47,8 +47,10 @@ void main() {
 
     final formFinder = find.byType(Form);
     final emailField = find.byType(TextFormField).first;
+    final passwordField = find.byType(TextFormField).at(1);
 
     await tester.enterText(emailField, 'user@example.com');
+    await tester.enterText(passwordField, 'password');
     final formState = tester.state<FormState>(formFinder);
     expect(formState.validate(), isTrue);
   });

--- a/test/screens/manage_services_page_test.dart
+++ b/test/screens/manage_services_page_test.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 
 import 'package:vogue_vault/l10n/app_localizations.dart';
 import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/models/service_offering.dart';
+import 'package:vogue_vault/models/service_type.dart';
 import 'package:vogue_vault/screens/manage_services_page.dart';
 import 'package:vogue_vault/services/appointment_service.dart';
 import 'package:vogue_vault/services/auth_service.dart';
@@ -33,7 +35,7 @@ class _FakeAppointmentService extends AppointmentService {
 }
 
 void main() {
-  testWidgets('saves updated offerings through service', (tester) async {
+  testWidgets('adding offering saves through service', (tester) async {
     final auth = _FakeAuthService();
     final appt = _FakeAppointmentService();
 
@@ -58,5 +60,41 @@ void main() {
 
     expect(appt.updated, isNotNull);
     expect(appt.updated!.offerings, isNotEmpty);
+  });
+
+  testWidgets('removing offering saves empty list', (tester) async {
+    final auth = _FakeAuthService();
+    final appt = _FakeAppointmentService();
+    appt.profile = appt.profile.copyWith(
+      offerings: [
+        ServiceOffering(
+          type: ServiceType.barber,
+          name: 'Cut',
+          price: 10,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appt),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ManageServicesPage(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.remove_circle));
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(appt.updated, isNotNull);
+    expect(appt.updated!.offerings, isEmpty);
   });
 }

--- a/test/screens/profile_page_test.dart
+++ b/test/screens/profile_page_test.dart
@@ -110,6 +110,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     await tester.enterText(
       find.widgetWithText(TextFormField, 'Current password'),
@@ -123,7 +124,10 @@ void main() {
       find.widgetWithText(TextFormField, 'Confirm password'),
       'new2',
     );
-    await tester.tap(find.text('Save'));
+    await tester.drag(find.byType(ListView), const Offset(0, -1000));
+    await tester.pumpAndSettle();
+    final saveButton = find.widgetWithText(ElevatedButton, 'Save');
+    await tester.tap(saveButton);
     await tester.pump();
     expect(find.text('Passwords do not match'), findsOneWidget);
   });
@@ -145,6 +149,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     await tester.enterText(
       find.widgetWithText(TextFormField, 'Email'),
@@ -163,7 +168,10 @@ void main() {
       'new',
     );
 
-    await tester.tap(find.text('Save'));
+    await tester.drag(find.byType(ListView), const Offset(0, -1000));
+    await tester.pumpAndSettle();
+    final saveButton = find.widgetWithText(ElevatedButton, 'Save');
+    await tester.tap(saveButton);
     await tester.pump();
 
     expect(auth.changedOld, 'old@example.com');
@@ -192,6 +200,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     expect(find.byTooltip('Home'), findsNothing);
     expect(find.byType(ServiceOfferingEditor), findsNothing);
@@ -214,6 +223,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     await tester.enterText(
       find.widgetWithText(TextFormField, 'First name'),
@@ -236,11 +246,15 @@ void main() {
       'pass',
     );
 
-    await tester.tap(find.text('Save'));
+    await tester.drag(find.byType(ListView), const Offset(0, -1000));
+    await tester.pumpAndSettle();
+    final saveButton = find.widgetWithText(ElevatedButton, 'Save');
+    await tester.tap(saveButton);
     await tester.pumpAndSettle();
 
     expect(auth.registeredEmail, 'new@example.com');
     expect(appt.addedUser, isNotNull);
     expect(appt.addedUser!.offerings, isEmpty);
+    expect(find.text('Please select at least one service'), findsNothing);
   });
 }

--- a/test/utils/date_format_test.dart
+++ b/test/utils/date_format_test.dart
@@ -6,7 +6,7 @@ void main() {
     const locale = 'en_US';
     final dt = DateTime(2023, 9, 10, 10, 0);
     final formatted = DateFormat.yMMMd(locale).add_jm().format(dt);
-    expect(formatted, 'Sep 10, 2023 10:00 AM');
+    expect(formatted, 'Sep 10, 2023 10:00 AM');
   });
 }
 

--- a/test/widgets/service_offering_editor_test.dart
+++ b/test/widgets/service_offering_editor_test.dart
@@ -16,10 +16,12 @@ void main() {
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: Form(
-          child: ServiceOfferingEditor(
-            offerings: offerings,
-            onChanged: (list) => offerings = list,
+        home: Scaffold(
+          body: Form(
+            child: ServiceOfferingEditor(
+              offerings: offerings,
+              onChanged: (list) => offerings = list,
+            ),
           ),
         ),
       ),
@@ -41,9 +43,11 @@ void main() {
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: ServiceOfferingEditor(
-          offerings: offerings,
-          onChanged: (list) => offerings = list,
+        home: Scaffold(
+          body: ServiceOfferingEditor(
+            offerings: offerings,
+            onChanged: (list) => offerings = list,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Ensure profile registration succeeds with no offerings and omit required-service error
- Add manage services page tests for adding and removing offerings
- Fix widget tests and adjust validation expectations

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68ac909d8c94832b8604994ba74737fc