### PR TITLE
Route user service editing to ManageServicesPage

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -10,7 +10,7 @@ import '../models/user_role.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../utils/image_picking.dart';
-import 'profile_page.dart';
+import 'manage_services_page.dart';
 
 class EditUserPage extends StatelessWidget {
   const EditUserPage({super.key});
@@ -163,13 +163,17 @@ class EditUserPage extends StatelessWidget {
                       Align(
                         alignment: Alignment.centerLeft,
                         child: TextButton(
-                          onPressed: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (_) => const ProfilePage(),
-                              ),
-                            );
-                          },
+                          onPressed: user == null
+                              ? null
+                              : () {
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (_) => ManageServicesPage(
+                                        userId: user.id,
+                                      ),
+                                    ),
+                                  );
+                                },
                           child: Text(
                             AppLocalizations.of(context)!.servicesTitle,
                           ),

--- a/lib/screens/manage_services_page.dart
+++ b/lib/screens/manage_services_page.dart
@@ -4,13 +4,14 @@ import 'package:provider/provider.dart';
 import '../l10n/app_localizations.dart';
 import '../models/service_offering.dart';
 import '../services/appointment_service.dart';
-import '../services/auth_service.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/service_offering_editor.dart';
 
 /// Page allowing professionals to manage their service offerings.
 class ManageServicesPage extends StatefulWidget {
-  const ManageServicesPage({super.key});
+  const ManageServicesPage({super.key, required this.userId});
+
+  final String userId;
 
   @override
   State<ManageServicesPage> createState() => _ManageServicesPageState();
@@ -23,9 +24,8 @@ class _ManageServicesPageState extends State<ManageServicesPage> {
   @override
   void initState() {
     super.initState();
-    final auth = context.read<AuthService>();
     final service = context.read<AppointmentService>();
-    _userId = auth.currentUser ?? '';
+    _userId = widget.userId;
     final user = service.getUser(_userId);
     _offerings = [...(user?.offerings ?? <ServiceOffering>[])];
   }

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -375,7 +375,7 @@ class _ProfilePageState extends State<ProfilePage> {
                     await Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => const ManageServicesPage(),
+                        builder: (_) => ManageServicesPage(userId: _userId),
                       ),
                     );
                     final service = context.read<AppointmentService>();

--- a/test/screens/manage_services_page_test.dart
+++ b/test/screens/manage_services_page_test.dart
@@ -48,7 +48,7 @@ void main() {
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: ManageServicesPage(),
+          home: ManageServicesPage(userId: 'test@example.com'),
         ),
       ),
     );
@@ -84,7 +84,7 @@ void main() {
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: ManageServicesPage(),
+          home: ManageServicesPage(userId: 'test@example.com'),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Replace ProfilePage navigation with ManageServicesPage in EditUserPage
- Allow ManageServicesPage to accept a user id and load the correct offerings
- Update profile page and tests to pass along the user id

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc495fa7c832badd88e9ec3693f8e