### PR TITLE
Display localized user roles

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -26,6 +26,7 @@
   "cannotDeleteSelfTooltip": "Cannot delete yourself",
   "newUserTitle": "New User",
   "editUserTitle": "Edit User",
+  "adminRole": "Admin",
   "professionalRole": "Professional",
   "cancelButton": "Cancel",
   "selectedProviderRemoved": "Previously selected provider was removed or unavailable. Please choose another.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -26,6 +26,7 @@
   "cannotDeleteSelfTooltip": "No puedes eliminarte a ti mismo",
   "newUserTitle": "Nuevo usuario",
   "editUserTitle": "Editar usuario",
+  "adminRole": "Administrador",
   "professionalRole": "Profesional",
   "cancelButton": "Cancelar",
   "selectedProviderRemoved": "El proveedor seleccionado previamente fue eliminado o no está disponible. Por favor elige otro.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -260,6 +260,12 @@ abstract class AppLocalizations {
   /// **'Professional'**
   String get professionalRole;
 
+  /// No description provided for @adminRole.
+  ///
+  /// In en, this message translates to:
+  /// **'Admin'**
+  String get adminRole;
+
   /// No description provided for @cancelButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editUserTitle => 'Edit User';
 
   @override
+  String get adminRole => 'Admin';
+
+  @override
   String get professionalRole => 'Professional';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -88,6 +88,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editUserTitle => 'Editar usuario';
 
   @override
+  String get adminRole => 'Administrador';
+
+  @override
   String get professionalRole => 'Profesional';
 
   @override

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -29,8 +29,16 @@ class EditUserPage extends StatelessWidget {
         itemBuilder: (context, index) {
           final user = users[index];
           final currentUser = context.watch<AuthService>().currentUser;
-          final roleText =
-              AppLocalizations.of(context)!.professionalRole;
+          final roleText = user.roles
+              .map((role) {
+                switch (role) {
+                  case UserRole.professional:
+                    return AppLocalizations.of(context)!.professionalRole;
+                  case UserRole.admin:
+                    return AppLocalizations.of(context)!.adminRole;
+                }
+              })
+              .join(', ');
           final isSelf = user.id == currentUser;
           return ListTile(
             leading: CircleAvatar(


### PR DESCRIPTION
## Summary
- Display each user's roles by joining their localized labels
- Add Admin role translations in English and Spanish

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68acc7f10120832ba9226407f34a1045