### PR TITLE
feat: add client management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'utils/color_palette.dart';
 import 'screens/auth_page.dart';
 import 'services/appointment_service.dart';
 import 'services/auth_service.dart';
+import 'services/client_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -19,6 +20,8 @@ Future<void> main() async {
 
   final appointmentService = AppointmentService();
   await appointmentService.init();
+  final clientService = ClientService(appointmentService);
+  await clientService.init();
   final authService = AuthService();
   await authService.init();
 
@@ -27,6 +30,9 @@ Future<void> main() async {
       providers: [
         ChangeNotifierProvider<AppointmentService>.value(
           value: appointmentService,
+        ),
+        ChangeNotifierProvider<ClientService>.value(
+          value: clientService,
         ),
         ChangeNotifierProvider<AuthService>.value(
           value: authService,

--- a/lib/models/client.dart
+++ b/lib/models/client.dart
@@ -1,0 +1,71 @@
+/// Represents a client that can book appointments.
+class Client {
+  /// Unique identifier for the client.
+  final String id;
+
+  /// Full name of the client.
+  final String name;
+
+  /// Contact details such as phone number or email.
+  final String contact;
+
+  /// Optional notes about the client.
+  final String? notes;
+
+  Client({
+    required this.id,
+    required this.name,
+    required this.contact,
+    this.notes,
+  });
+
+  /// Returns a copy of this client with the given fields replaced.
+  Client copyWith({
+    String? id,
+    String? name,
+    String? contact,
+    String? notes,
+  }) {
+    return Client(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      contact: contact ?? this.contact,
+      notes: notes ?? this.notes,
+    );
+  }
+
+  /// Creates a [Client] from a JSON-compatible [map].
+  factory Client.fromMap(Map<String, dynamic> map) {
+    return Client(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      contact: map['contact'] as String,
+      notes: map['notes'] as String?,
+    );
+  }
+
+  /// Converts this client into a JSON-compatible map.
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'contact': contact,
+      'notes': notes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Client &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          contact == other.contact &&
+          notes == other.notes;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^ name.hashCode ^ contact.hashCode ^ notes.hashCode;
+}
+

--- a/lib/screens/clients_page.dart
+++ b/lib/screens/clients_page.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/client.dart';
+import '../services/client_service.dart';
+
+class ClientsPage extends StatelessWidget {
+  const ClientsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<ClientService>();
+    final clients = service.clients;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Clients'),
+      ),
+      body: ListView.builder(
+        itemCount: clients.length,
+        itemBuilder: (context, index) {
+          final client = clients[index];
+          return ListTile(
+            title: Text(client.name),
+            subtitle: Text(client.contact),
+            onTap: () => _editClient(context, client),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _editClient(context, null),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _editClient(BuildContext context, Client? client) async {
+    final service = context.read<ClientService>();
+    final nameController =
+        TextEditingController(text: client != null ? client.name : '');
+    final contactController =
+        TextEditingController(text: client != null ? client.contact : '');
+    final notesController =
+        TextEditingController(text: client != null ? client.notes ?? '' : '');
+
+    await showDialog(
+      context: context,
+      builder: (context) {
+        final appointments =
+            client != null ? service.history(client.id) : <dynamic>[];
+        return AlertDialog(
+          title: Text(client == null ? 'New Client' : 'Edit Client'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: contactController,
+                  decoration: const InputDecoration(labelText: 'Contact'),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: notesController,
+                  decoration: const InputDecoration(labelText: 'Notes'),
+                ),
+                if (appointments.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text('Past Appointments'),
+                  ),
+                  for (final appt in appointments)
+                    ListTile(
+                      title: Text(appt.service.name),
+                      subtitle: Text(appt.dateTime.toLocal().toString()),
+                    ),
+                ]
+              ],
+            ),
+          ),
+          actions: [
+            if (client != null)
+              TextButton(
+                onPressed: () async {
+                  await service.deleteClient(client.id);
+                  if (context.mounted) Navigator.of(context).pop();
+                },
+                child: const Text('Delete'),
+              ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final id = client?.id ?? const Uuid().v4();
+                final updated = Client(
+                  id: id,
+                  name: nameController.text,
+                  contact: contactController.text,
+                  notes: notesController.text.isEmpty
+                      ? null
+                      : notesController.text,
+                );
+                if (client == null) {
+                  await service.addClient(updated);
+                } else {
+                  await service.updateClient(updated);
+                }
+                if (context.mounted) Navigator.of(context).pop();
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -7,6 +7,8 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 import '../models/appointment.dart';
 import '../models/service_type.dart';
 import '../services/appointment_service.dart';
+import '../services/client_service.dart';
+import '../models/client.dart';
 import '../utils/service_type_utils.dart';
 
 class EditAppointmentPage extends StatefulWidget {
@@ -25,6 +27,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   late Duration _duration;
   late final TextEditingController _guestNameController;
   late final TextEditingController _guestContactController;
+  String? _selectedClientId;
 
   @override
   void initState() {
@@ -37,6 +40,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
         TextEditingController(text: widget.appointment?.guestName ?? '');
     _guestContactController =
         TextEditingController(text: widget.appointment?.guestContact ?? '');
+    _selectedClientId = widget.appointment?.clientId;
   }
 
   @override
@@ -49,6 +53,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   @override
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
+    final clientService = context.watch<ClientService>();
     final locale = Localizations.localeOf(context).toString();
     final isEditing = widget.appointment != null;
 
@@ -70,20 +75,118 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
           key: _formKey,
           child: Column(
             children: [
+              DropdownButtonFormField<String?>(
+                value: _selectedClientId,
+                decoration: const InputDecoration(labelText: 'Client'),
+                items: [
+                  const DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text('Guest'),
+                  ),
+                  ...clientService.clients.map(
+                    (c) => DropdownMenuItem<String?>(
+                      value: c.id,
+                      child: Text(c.name),
+                    ),
+                  ),
+                ],
+                onChanged: (value) {
+                  setState(() {
+                    _selectedClientId = value;
+                    if (value != null) {
+                      final client = clientService.getClient(value);
+                      _guestContactController.text = client?.contact ?? '';
+                    }
+                  });
+                },
+              ),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton(
+                  onPressed: () async {
+                    final nameController = TextEditingController();
+                    final contactController = TextEditingController();
+                    final notesController = TextEditingController();
+                    final newClient = await showDialog<Client>(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialog(
+                          title: const Text('New Client'),
+                          content: SingleChildScrollView(
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                TextField(
+                                  controller: nameController,
+                                  decoration:
+                                      const InputDecoration(labelText: 'Name'),
+                                ),
+                                const SizedBox(height: 8),
+                                TextField(
+                                  controller: contactController,
+                                  decoration:
+                                      const InputDecoration(labelText: 'Contact'),
+                                ),
+                                const SizedBox(height: 8),
+                                TextField(
+                                  controller: notesController,
+                                  decoration:
+                                      const InputDecoration(labelText: 'Notes'),
+                                ),
+                              ],
+                            ),
+                          ),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.of(context).pop(),
+                              child: const Text('Cancel'),
+                            ),
+                            TextButton(
+                              onPressed: () {
+                                final client = Client(
+                                  id: const Uuid().v4(),
+                                  name: nameController.text,
+                                  contact: contactController.text,
+                                  notes: notesController.text.isEmpty
+                                      ? null
+                                      : notesController.text,
+                                );
+                                Navigator.of(context).pop(client);
+                              },
+                              child: const Text('Save'),
+                            ),
+                          ],
+                        );
+                      },
+                    );
+                    if (newClient != null) {
+                      await clientService.addClient(newClient);
+                      setState(() {
+                        _selectedClientId = newClient.id;
+                        _guestContactController.text = newClient.contact;
+                      });
+                    }
+                  },
+                  child: const Text('Add Client'),
+                ),
+              ),
               TextFormField(
                 controller: _guestNameController,
                 decoration: InputDecoration(
                   labelText: AppLocalizations.of(context)!.guestNameLabel,
                 ),
-                validator: (value) => value == null || value.isEmpty
-                    ? AppLocalizations.of(context)!.nameRequired
-                    : null,
+                validator: (value) =>
+                    _selectedClientId == null && (value == null || value.isEmpty)
+                        ? AppLocalizations.of(context)!.nameRequired
+                        : null,
+                enabled: _selectedClientId == null,
               ),
               TextFormField(
                 controller: _guestContactController,
                 decoration: InputDecoration(
                   labelText: AppLocalizations.of(context)!.guestContactLabel,
                 ),
+                enabled: _selectedClientId == null,
               ),
               DropdownButtonFormField<ServiceType>(
                 value: _service,
@@ -160,9 +263,13 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                       widget.appointment?.id ?? const Uuid().v4();
                   final newAppt = Appointment(
                     id: id,
-                    clientId: widget.appointment?.clientId,
-                    guestName: _guestNameController.text,
-                    guestContact: _guestContactController.text,
+                    clientId: _selectedClientId,
+                    guestName: _selectedClientId == null
+                        ? _guestNameController.text
+                        : null,
+                    guestContact: _selectedClientId == null
+                        ? _guestContactController.text
+                        : null,
                     providerId: widget.appointment?.providerId,
                     service: _service,
                     dateTime: _dateTime,

--- a/lib/services/client_service.dart
+++ b/lib/services/client_service.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/client.dart';
+import '../models/appointment.dart';
+import 'appointment_service.dart';
+
+class ClientService extends ChangeNotifier {
+  static const _clientsBoxName = 'clients';
+
+  final AppointmentService _appointmentService;
+  late Box _clientsBox;
+  bool _initialized = false;
+
+  ClientService(this._appointmentService);
+
+  bool get isInitialized => _initialized;
+
+  Future<void> init() async {
+    _clientsBox = await Hive.openBox(_clientsBoxName);
+    _initialized = true;
+  }
+
+  void _ensureInitialized() {
+    if (!_initialized) {
+      throw StateError('ClientService has not been initialized.');
+    }
+  }
+
+  List<Client> get clients {
+    if (!_initialized) return [];
+    return _clientsBox.values
+        .map((m) => Client.fromMap(Map<String, dynamic>.from(m)))
+        .toList();
+  }
+
+  Client? getClient(String id) {
+    _ensureInitialized();
+    final map = _clientsBox.get(id);
+    if (map == null) return null;
+    return Client.fromMap(Map<String, dynamic>.from(map));
+  }
+
+  Future<void> addClient(Client client) async {
+    _ensureInitialized();
+    await _clientsBox.put(client.id, client.toMap());
+    notifyListeners();
+  }
+
+  Future<void> updateClient(Client client) async {
+    _ensureInitialized();
+    await _clientsBox.put(client.id, client.toMap());
+    notifyListeners();
+  }
+
+  Future<void> deleteClient(String id) async {
+    _ensureInitialized();
+    await _clientsBox.delete(id);
+    notifyListeners();
+  }
+
+  List<Appointment> history(String clientId) {
+    _ensureInitialized();
+    final now = DateTime.now();
+    return _appointmentService.appointments
+        .where((a) => a.clientId == clientId && a.dateTime.isBefore(now))
+        .toList();
+  }
+
+  @override
+  void dispose() {
+    if (_initialized) {
+      _clientsBox.close();
+    }
+    super.dispose();
+  }
+}
+

--- a/test/models/client_test.dart
+++ b/test/models/client_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:vogue_vault/models/client.dart';
+
+void main() {
+  group('Client model', () {
+    test('toMap and fromMap produce equivalent objects', () {
+      const uuid = Uuid();
+      final client = Client(
+        id: uuid.v4(),
+        name: 'Alice',
+        contact: 'alice@example.com',
+        notes: 'VIP',
+      );
+      final map = client.toMap();
+      final from = Client.fromMap(map);
+      expect(from.id, client.id);
+      expect(from.name, client.name);
+      expect(from.contact, client.contact);
+      expect(from.notes, client.notes);
+    });
+
+    test('clients with same values are equal', () {
+      const uuid = Uuid();
+      final id = uuid.v4();
+      final c1 = Client(id: id, name: 'Bob', contact: '123');
+      final c2 = Client(id: id, name: 'Bob', contact: '123');
+      expect(c1, equals(c2));
+      expect(c1.hashCode, equals(c2.hashCode));
+    });
+
+    test('clients with different values are not equal', () {
+      const uuid = Uuid();
+      final c1 = Client(id: uuid.v4(), name: 'A', contact: '1');
+      final c2 = Client(id: uuid.v4(), name: 'B', contact: '2');
+      expect(c1, isNot(equals(c2)));
+    });
+  });
+}
+

--- a/test/services/client_service_test.dart
+++ b/test/services/client_service_test.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/services/client_service.dart';
+import 'package:vogue_vault/models/client.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/service_type.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('client CRUD operations', () async {
+    final apptService = AppointmentService();
+    await apptService.init();
+    final service = ClientService(apptService);
+    await service.init();
+
+    const uuid = Uuid();
+    final client = Client(id: uuid.v4(), name: 'Alice', contact: '1');
+    await service.addClient(client);
+    expect(service.clients, hasLength(1));
+
+    final updated = client.copyWith(name: 'Bob');
+    await service.updateClient(updated);
+    expect(service.getClient(client.id)?.name, 'Bob');
+
+    await service.deleteClient(client.id);
+    expect(service.clients, isEmpty);
+  });
+
+  test('history returns only past appointments', () async {
+    final apptService = AppointmentService();
+    await apptService.init();
+    final service = ClientService(apptService);
+    await service.init();
+
+    const uuid = Uuid();
+    final clientId = uuid.v4();
+    await service.addClient(Client(id: clientId, name: 'A', contact: '1'));
+
+    final past = Appointment(
+      id: uuid.v4(),
+      clientId: clientId,
+      service: ServiceType.barber,
+      dateTime: DateTime.now().subtract(const Duration(days: 1)),
+      duration: const Duration(hours: 1),
+    );
+    final future = Appointment(
+      id: uuid.v4(),
+      clientId: clientId,
+      service: ServiceType.barber,
+      dateTime: DateTime.now().add(const Duration(days: 1)),
+      duration: const Duration(hours: 1),
+    );
+    await apptService.addAppointment(past);
+    await apptService.addAppointment(future);
+
+    final hist = service.history(clientId);
+    expect(hist.map((a) => a.id), [past.id]);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add Client model and service for CRUD and history
- build clients page for listing and editing clients with past appointments
- enhance appointment editing to link appointments to saved clients

## Testing
- `flutter test test/models/client_test.dart test/services/client_service_test.dart` *(fails: command not found)*
- `dart test test/models/client_test.dart test/services/client_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9256bbdc832b9c9677e7a4d83337