### PR TITLE
Rename users tooltip to customers

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,7 +5,7 @@
   "calendarTitle": "Calendar",
   "homeTooltip": "Home",
   "profileTooltip": "Profile",
-  "usersTooltip": "Users",
+  "customersTooltip": "Customers",
   "calendarTooltip": "Calendar",
   "unknownUser": "Unknown",
   "userPhotoLabel": "User photo",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -5,7 +5,7 @@
   "calendarTitle": "Calendario",
   "homeTooltip": "Inicio",
   "profileTooltip": "Perfil",
-  "usersTooltip": "Usuarios",
+  "customersTooltip": "Clientes",
   "calendarTooltip": "Calendario",
   "unknownUser": "Desconocido",
   "userPhotoLabel": "Foto del usuario",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -62,7 +62,8 @@ import 'app_localizations_es.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -70,7 +71,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -82,7 +84,8 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -125,11 +128,11 @@ abstract class AppLocalizations {
   /// **'Profile'**
   String get profileTooltip;
 
-  /// No description provided for @usersTooltip.
+  /// No description provided for @customersTooltip.
   ///
   /// In en, this message translates to:
-  /// **'Users'**
-  String get usersTooltip;
+  /// **'Customers'**
+  String get customersTooltip;
 
   /// No description provided for @calendarTooltip.
   ///
@@ -450,7 +453,8 @@ abstract class AppLocalizations {
   String get appointmentConflict;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -459,25 +463,25 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en', 'es'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['en', 'es'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en': return AppLocalizationsEn();
-    case 'es': return AppLocalizationsEs();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -24,7 +24,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileTooltip => 'Profile';
 
   @override
-  String get usersTooltip => 'Users';
+  String get customersTooltip => 'Customers';
 
   @override
   String get calendarTooltip => 'Calendar';
@@ -39,7 +39,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileTitle => 'Profile';
 
   @override
-  String get imageSelectionUnsupported => 'Image selection not supported on this platform';
+  String get imageSelectionUnsupported =>
+      'Image selection not supported on this platform';
 
   @override
   String get nameLabel => 'Name';
@@ -183,5 +184,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get serviceTypeTattoo => 'Tattoo Artist';
 
   @override
-  String get appointmentConflict => 'Appointment conflicts with existing booking';
+  String get appointmentConflict =>
+      'Appointment conflicts with existing booking';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -24,7 +24,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileTooltip => 'Perfil';
 
   @override
-  String get usersTooltip => 'Usuarios';
+  String get customersTooltip => 'Clientes';
 
   @override
   String get calendarTooltip => 'Calendario';
@@ -39,7 +39,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileTitle => 'Perfil';
 
   @override
-  String get imageSelectionUnsupported => 'La selección de imágenes no es compatible con esta plataforma';
+  String get imageSelectionUnsupported =>
+      'La selección de imágenes no es compatible con esta plataforma';
 
   @override
   String get nameLabel => 'Nombre';
@@ -183,5 +184,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get serviceTypeTattoo => 'Tatuador';
 
   @override
-  String get appointmentConflict => 'La cita entra en conflicto con una reserva existente';
+  String get appointmentConflict =>
+      'La cita entra en conflicto con una reserva existente';
 }

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -35,7 +35,7 @@ class AppointmentsPage extends StatelessWidget {
         ),
         IconButton(
           icon: const Icon(Icons.group),
-          tooltip: AppLocalizations.of(context)!.usersTooltip,
+          tooltip: AppLocalizations.of(context)!.customersTooltip,
           onPressed: () {
             Navigator.push(
               context,
@@ -96,8 +96,7 @@ class AppointmentsPage extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) =>
-                            EditAppointmentPage(appointment: appt),
+                        builder: (_) => EditAppointmentPage(appointment: appt),
                       ),
                     );
                   },

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -23,24 +23,23 @@ class EditUserPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.usersTooltip),
+        title: Text(AppLocalizations.of(context)!.customersTooltip),
       ),
       body: ListView.builder(
         itemCount: users.length,
         itemBuilder: (context, index) {
           final user = users[index];
           final auth = context.watch<AuthService>();
-          final roleText = user.roles
-              .map((role) {
-                switch (role) {
-                  case UserRole.professional:
-                    return AppLocalizations.of(context)!.professionalRole;
-                  case UserRole.admin:
-                    return AppLocalizations.of(context)!.adminRole;
-                }
-              })
-              .join(', ');
-          final isSelf = auth.currentUser != null && user.id == auth.currentUser;
+          final roleText = user.roles.map((role) {
+            switch (role) {
+              case UserRole.professional:
+                return AppLocalizations.of(context)!.professionalRole;
+              case UserRole.admin:
+                return AppLocalizations.of(context)!.adminRole;
+            }
+          }).join(', ');
+          final isSelf =
+              auth.currentUser != null && user.id == auth.currentUser;
           return ListTile(
             leading: CircleAvatar(
               backgroundImage: user.photoBytes != null
@@ -87,7 +86,8 @@ class EditUserPage extends StatelessWidget {
     );
   }
 
-  Future<void> _showUserDialog(BuildContext context, {UserProfile? user}) async {
+  Future<void> _showUserDialog(BuildContext context,
+      {UserProfile? user}) async {
     final firstNameController =
         TextEditingController(text: user?.firstName ?? '');
     final lastNameController =
@@ -117,9 +117,8 @@ class EditUserPage extends StatelessWidget {
                           if (!isImagePickerSupported) {
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
-                                content: Text(
-                                    AppLocalizations.of(context)!
-                                        .imageSelectionUnsupported),
+                                content: Text(AppLocalizations.of(context)!
+                                    .imageSelectionUnsupported),
                               ),
                             );
                             return;
@@ -144,11 +143,10 @@ class EditUserPage extends StatelessWidget {
                         decoration: InputDecoration(
                             labelText:
                                 AppLocalizations.of(context)!.firstNameLabel),
-                        validator: (value) =>
-                            value == null || value.trim().isEmpty
-                                ? AppLocalizations.of(context)!
-                                    .firstNameRequired
-                                : null,
+                        validator: (value) => value == null ||
+                                value.trim().isEmpty
+                            ? AppLocalizations.of(context)!.firstNameRequired
+                            : null,
                       ),
                       TextFormField(
                         controller: lastNameController,
@@ -157,8 +155,7 @@ class EditUserPage extends StatelessWidget {
                                 AppLocalizations.of(context)!.lastNameLabel),
                         validator: (value) =>
                             value == null || value.trim().isEmpty
-                                ? AppLocalizations.of(context)!
-                                    .lastNameRequired
+                                ? AppLocalizations.of(context)!.lastNameRequired
                                 : null,
                       ),
                       TextFormField(
@@ -201,8 +198,7 @@ class EditUserPage extends StatelessWidget {
                       return;
                     }
                     final service = context.read<AppointmentService>();
-                    final id =
-                        user?.id ?? const Uuid().v4();
+                    final id = user?.id ?? const Uuid().v4();
                     final newUser = UserProfile(
                       id: id,
                       firstName: firstNameController.text.trim(),
@@ -235,5 +231,4 @@ class EditUserPage extends StatelessWidget {
       nicknameController.dispose();
     }
   }
-
 }


### PR DESCRIPTION
## Summary
- rename `usersTooltip` localization key to `customersTooltip`
- update generated localization files and related screens to use `customersTooltip`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68aded14fedc832b931125eca78358ba