### PR TITLE
Exclude current user from edit users list

### DIFF
--- a/test/screens/edit_user_page_test.dart
+++ b/test/screens/edit_user_page_test.dart
@@ -62,7 +62,7 @@ void main() {
     expect(find.byType(ProfilePage), findsOneWidget);
   });
 
-  testWidgets('delete button disabled for current user', (tester) async {
+  testWidgets('current user does not appear in list', (tester) async {
     final auth = _FakeAuthService();
     final user = UserProfile(
       id: 'test',
@@ -86,9 +86,7 @@ void main() {
       ),
     );
 
-    final deleteFinder = find.widgetWithIcon(IconButton, Icons.delete);
-    expect(deleteFinder, findsOneWidget);
-    final button = tester.widget<IconButton>(deleteFinder);
-    expect(button.onPressed, isNull);
+    expect(find.text('Test User'), findsNothing);
+    expect(find.widgetWithIcon(IconButton, Icons.delete), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- filter out the signed-in user when building the users list on Edit User page
- update tests to verify that the current user no longer appears in the list

## Testing
- `flutter test test/screens/edit_user_page_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf0264978832ba6ab55a15c568b25