### PR TITLE
Remove client fields from appointments

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -5,16 +5,6 @@ class Appointment {
   /// Unique identifier for the appointment.
   final String id;
 
-  /// Identifier of the user acting as the client.  If `null`, this appointment
-  /// represents a guest who does not have an account in the system.
-  final String? clientId;
-
-  /// Display name for a guest client when [clientId] is `null`.
-  final String? guestName;
-
-  /// Optional contact information for a guest client.
-  final String? guestContact;
-
   /// Identifier of the user acting as the service provider.
   ///
   /// This field is optional as appointments can now be created without
@@ -33,9 +23,6 @@ class Appointment {
   /// Creates a new [Appointment].
   Appointment({
     required this.id,
-    this.clientId,
-    this.guestName,
-    this.guestContact,
     this.providerId,
     required this.service,
     required this.dateTime,
@@ -45,9 +32,6 @@ class Appointment {
   /// Returns a copy of this appointment with the given fields replaced.
   Appointment copyWith({
     String? id,
-    String? clientId,
-    String? guestName,
-    String? guestContact,
     String? providerId,
     ServiceType? service,
     DateTime? dateTime,
@@ -55,9 +39,6 @@ class Appointment {
   }) {
     return Appointment(
       id: id ?? this.id,
-      clientId: clientId ?? this.clientId,
-      guestName: guestName ?? this.guestName,
-      guestContact: guestContact ?? this.guestContact,
       providerId: providerId ?? this.providerId,
       service: service ?? this.service,
       dateTime: dateTime ?? this.dateTime,
@@ -69,9 +50,6 @@ class Appointment {
   factory Appointment.fromMap(Map<String, dynamic> map) {
     return Appointment(
       id: map['id'] as String,
-      clientId: map['clientId'] as String?,
-      guestName: map['guestName'] as String?,
-      guestContact: map['guestContact'] as String?,
       providerId: map['providerId'] as String?,
       service: ServiceType.values.byName(map['service'] as String),
       dateTime: DateTime.parse(map['dateTime'] as String),
@@ -83,9 +61,6 @@ class Appointment {
   Map<String, dynamic> toMap() {
     return {
       'id': id,
-      'clientId': clientId,
-      'guestName': guestName,
-      'guestContact': guestContact,
       'providerId': providerId,
       'service': service.name,
       'dateTime': dateTime.toIso8601String(),
@@ -99,19 +74,14 @@ class Appointment {
       other is Appointment &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          clientId == other.clientId &&
-          guestName == other.guestName &&
-          guestContact == other.guestContact &&
           providerId == other.providerId &&
           service == other.service &&
           dateTime == other.dateTime &&
           duration == other.duration;
 
   @override
-  int get hashCode => id.hashCode ^
-      clientId.hashCode ^
-      guestName.hashCode ^
-      guestContact.hashCode ^
+  int get hashCode =>
+      id.hashCode ^
       providerId.hashCode ^
       service.hashCode ^
       dateTime.hashCode ^

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -71,11 +71,10 @@ class AppointmentsPage extends StatelessWidget {
               itemCount: appointments.length,
               itemBuilder: (context, index) {
                 final Appointment appt = appointments[index];
-                final clientName = appt.clientId != null
-                    ? service.getUser(appt.clientId!)?.name ??
-                        AppLocalizations.of(context)!.unknownUser
-                    : appt.guestName ??
-                        AppLocalizations.of(context)!.unknownUser;
+                final providerName = appt.providerId != null
+                    ? service.getUser(appt.providerId!)?.name ??
+                          AppLocalizations.of(context)!.unknownUser
+                    : AppLocalizations.of(context)!.unknownUser;
                 return ListTile(
                   leading: CircleAvatar(
                     backgroundColor: serviceTypeColor(appt.service),
@@ -85,7 +84,7 @@ class AppointmentsPage extends StatelessWidget {
                     ),
                   ),
                   title: Text(
-                    '$clientName - ${serviceTypeLabel(context, appt.service)}',
+                    '${serviceTypeLabel(context, appt.service)} - $providerName',
                   ),
                   subtitle: Text(
                     '${DateFormat.yMMMd(locale).format(appt.dateTime.toLocal())} '
@@ -113,9 +112,7 @@ class AppointmentsPage extends StatelessWidget {
         onPressed: () {
           Navigator.push(
             context,
-            MaterialPageRoute(
-              builder: (_) => const EditAppointmentPage(),
-            ),
+            MaterialPageRoute(builder: (_) => const EditAppointmentPage()),
           );
         },
         child: const Icon(Icons.add),

--- a/lib/screens/calendar_page.dart
+++ b/lib/screens/calendar_page.dart
@@ -69,11 +69,10 @@ class _CalendarPageState extends State<CalendarPage> {
                     itemCount: selectedAppointments.length,
                     itemBuilder: (context, index) {
                       final appt = selectedAppointments[index];
-                      final clientName = appt.clientId != null
-                          ? service.getUser(appt.clientId!)?.name ??
-                              AppLocalizations.of(context)!.unknownUser
-                          : appt.guestName ??
-                              AppLocalizations.of(context)!.unknownUser;
+                      final providerName = appt.providerId != null
+                          ? service.getUser(appt.providerId!)?.name ??
+                                AppLocalizations.of(context)!.unknownUser
+                          : AppLocalizations.of(context)!.unknownUser;
                       return ListTile(
                         leading: CircleAvatar(
                           backgroundColor: serviceTypeColor(appt.service),
@@ -83,8 +82,8 @@ class _CalendarPageState extends State<CalendarPage> {
                           ),
                         ),
                         title: Text(
-                          '$clientName - '
-                          '${serviceTypeLabel(context, appt.service)}',
+                          '${serviceTypeLabel(context, appt.service)} - '
+                          '$providerName',
                         ),
                         subtitle: Text(
                           '${DateFormat.jm(locale).format(appt.dateTime.toLocal())} - '
@@ -99,4 +98,3 @@ class _CalendarPageState extends State<CalendarPage> {
     );
   }
 }
-

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -23,26 +23,20 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   late ServiceType _service;
   DateTime _dateTime = DateTime.now();
   late Duration _duration;
-  late final TextEditingController _guestNameController;
-  late final TextEditingController _guestContactController;
 
   @override
   void initState() {
     super.initState();
     _service =
-        widget.appointment?.service ?? widget.initialService ?? ServiceType.barber;
+        widget.appointment?.service ??
+        widget.initialService ??
+        ServiceType.barber;
     _dateTime = widget.appointment?.dateTime ?? DateTime.now();
     _duration = widget.appointment?.duration ?? const Duration(hours: 1);
-    _guestNameController =
-        TextEditingController(text: widget.appointment?.guestName ?? '');
-    _guestContactController =
-        TextEditingController(text: widget.appointment?.guestContact ?? '');
   }
 
   @override
   void dispose() {
-    _guestNameController.dispose();
-    _guestContactController.dispose();
     super.dispose();
   }
 
@@ -54,9 +48,11 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(isEditing
-            ? AppLocalizations.of(context)!.editAppointmentTitle
-            : AppLocalizations.of(context)!.newAppointmentTitle),
+        title: Text(
+          isEditing
+              ? AppLocalizations.of(context)!.editAppointmentTitle
+              : AppLocalizations.of(context)!.newAppointmentTitle,
+        ),
       ),
       resizeToAvoidBottomInset: true,
       body: SingleChildScrollView(
@@ -70,26 +66,11 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
           key: _formKey,
           child: Column(
             children: [
-              TextFormField(
-                controller: _guestNameController,
-                decoration: InputDecoration(
-                  labelText: AppLocalizations.of(context)!.guestNameLabel,
-                ),
-                validator: (value) =>
-                    value == null || value.isEmpty
-                        ? AppLocalizations.of(context)!.nameRequired
-                        : null,
-              ),
-              TextFormField(
-                controller: _guestContactController,
-                decoration: InputDecoration(
-                  labelText: AppLocalizations.of(context)!.guestContactLabel,
-                ),
-              ),
               DropdownButtonFormField<ServiceType>(
                 value: _service,
                 decoration: InputDecoration(
-                    labelText: AppLocalizations.of(context)!.serviceLabel),
+                  labelText: AppLocalizations.of(context)!.serviceLabel,
+                ),
                 items: ServiceType.values
                     .map(
                       (s) => DropdownMenuItem<ServiceType>(
@@ -110,12 +91,13 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ),
               DropdownButtonFormField<int>(
                 value: _duration.inMinutes,
-                decoration: const InputDecoration(labelText: 'Duration (minutes)'),
+                decoration: const InputDecoration(
+                  labelText: 'Duration (minutes)',
+                ),
                 items: List.generate(8, (i) => (i + 1) * 15)
-                    .map((m) => DropdownMenuItem<int>(
-                          value: m,
-                          child: Text('$m'),
-                        ))
+                    .map(
+                      (m) => DropdownMenuItem<int>(value: m, child: Text('$m')),
+                    )
                     .toList(),
                 onChanged: (value) {
                   if (value == null) return;
@@ -127,7 +109,11 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               const SizedBox(height: 12),
               Row(
                 children: [
-                  Text(DateFormat.yMMMd(locale).add_jm().format(_dateTime.toLocal())),
+                  Text(
+                    DateFormat.yMMMd(
+                      locale,
+                    ).add_jm().format(_dateTime.toLocal()),
+                  ),
                   const SizedBox(width: 8),
                   TextButton(
                     onPressed: () async {
@@ -145,11 +131,15 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                       if (time == null) return;
                       setState(() {
                         _dateTime = DateTime(
-                            date.year, date.month, date.day, time.hour, time.minute);
+                          date.year,
+                          date.month,
+                          date.day,
+                          time.hour,
+                          time.minute,
+                        );
                       });
                     },
-                    child: Text(
-                        AppLocalizations.of(context)!.selectDateButton),
+                    child: Text(AppLocalizations.of(context)!.selectDateButton),
                   ),
                 ],
               ),
@@ -157,13 +147,9 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ElevatedButton(
                 onPressed: () async {
                   if (!_formKey.currentState!.validate()) return;
-                  final id =
-                      widget.appointment?.id ?? const Uuid().v4();
+                  final id = widget.appointment?.id ?? const Uuid().v4();
                   final newAppt = Appointment(
                     id: id,
-                    clientId: null,
-                    guestName: _guestNameController.text,
-                    guestContact: _guestContactController.text,
                     providerId: widget.appointment?.providerId,
                     service: _service,
                     dateTime: _dateTime,

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -51,20 +51,20 @@ class AppointmentService extends ChangeNotifier {
       final userMap = Map<String, dynamic>.from(m);
       return UserProfile.fromMap({
         ...userMap,
-        'offerings': (userMap['offerings'] as List?)
+        'offerings':
+            (userMap['offerings'] as List?)
                 ?.map((e) => Map<String, dynamic>.from(e as Map))
                 .toList() ??
             <Map<String, dynamic>>[],
       });
     }).toList();
   }
+
   List<UserProfile> get providers =>
       users.where((u) => u.roles.contains(UserRole.professional)).toList();
 
   List<UserProfile> providersFor(ServiceType type) =>
-      providers
-          .where((p) => p.offerings.any((o) => o.type == type))
-          .toList();
+      providers.where((p) => p.offerings.any((o) => o.type == type)).toList();
 
   UserProfile? getUser(String id) {
     _ensureInitialized();
@@ -73,7 +73,8 @@ class AppointmentService extends ChangeNotifier {
     final userMap = Map<String, dynamic>.from(map);
     return UserProfile.fromMap({
       ...userMap,
-      'offerings': (userMap['offerings'] as List?)
+      'offerings':
+          (userMap['offerings'] as List?)
               ?.map((e) => Map<String, dynamic>.from(e as Map))
               .toList() ??
           <Map<String, dynamic>>[],
@@ -108,17 +109,13 @@ class AppointmentService extends ChangeNotifier {
     _ensureInitialized();
 
     final affected = _appointmentsBox.values
-        .map((m) =>
-            Appointment.fromMap(Map<String, dynamic>.from(m)))
-        .where((a) => a.clientId == id || a.providerId == id)
+        .map((m) => Appointment.fromMap(Map<String, dynamic>.from(m)))
+        .where((a) => a.providerId == id)
         .toList();
 
     if (reassignedUserId != null) {
       for (final appt in affected) {
-        final updated = appt.copyWith(
-          clientId: appt.clientId == id ? reassignedUserId : appt.clientId,
-          providerId: appt.providerId == id ? reassignedUserId : appt.providerId,
-        );
+        final updated = appt.copyWith(providerId: reassignedUserId);
         await _appointmentsBox.put(updated.id, updated.toMap());
       }
     } else {
@@ -141,8 +138,7 @@ class AppointmentService extends ChangeNotifier {
       if (existing.id == appointment.id) return false;
       final existingStart = existing.dateTime;
       final existingEnd = existingStart.add(existing.duration);
-      return newStart.isBefore(existingEnd) &&
-          existingStart.isBefore(newEnd);
+      return newStart.isBefore(existingEnd) && existingStart.isBefore(newEnd);
     });
   }
 
@@ -182,14 +178,8 @@ class AppointmentService extends ChangeNotifier {
     for (final m in _appointmentsBox.values) {
       final map = Map<String, dynamic>.from(m);
       final appt = Appointment.fromMap(map);
-      var updated = appt;
-      if (appt.clientId == oldId) {
-        updated = updated.copyWith(clientId: newId);
-      }
       if (appt.providerId == oldId) {
-        updated = updated.copyWith(providerId: newId);
-      }
-      if (updated != appt) {
+        final updated = appt.copyWith(providerId: newId);
         await _appointmentsBox.put(updated.id, updated.toMap());
       }
     }

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -8,11 +8,9 @@ void main() {
     test('toMap and fromMap produce equivalent objects', () {
       const uuid = Uuid();
       final id = uuid.v4();
-      final clientId = uuid.v4();
       final providerId = uuid.v4();
       final appointment = Appointment(
         id: id,
-        clientId: clientId,
         providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
@@ -22,44 +20,29 @@ void main() {
       final from = Appointment.fromMap(map);
 
       expect(from.id, appointment.id);
-      expect(from.clientId, appointment.clientId);
       expect(from.providerId, appointment.providerId);
       expect(from.service, appointment.service);
       expect(from.dateTime, appointment.dateTime);
       expect(from.duration, appointment.duration);
     });
 
-    test('supports guest clients', () {
-      const uuid = Uuid();
-      final appointment = Appointment(
-        id: uuid.v4(),
-        guestName: 'Walk-in',
-        guestContact: '555-1234',
-        service: ServiceType.barber,
-        dateTime: DateTime(2023, 9, 10, 11, 0),
-        duration: const Duration(minutes: 30),
-      );
-      final map = appointment.toMap();
-      final from = Appointment.fromMap(map);
-
-      expect(from.clientId, isNull);
-      expect(from.guestName, appointment.guestName);
-      expect(from.guestContact, appointment.guestContact);
-    });
-
     test('fromMap validates required data', () {
       const uuid = Uuid();
       final missingFields = {'id': uuid.v4()};
-      expect(() => Appointment.fromMap(missingFields), throwsA(isA<TypeError>()));
+      expect(
+        () => Appointment.fromMap(missingFields),
+        throwsA(isA<TypeError>()),
+      );
 
       final invalidDate = {
         'id': uuid.v4(),
-        'clientId': uuid.v4(),
-        'providerId': uuid.v4(),
         'service': 'barber',
         'dateTime': 'invalid',
       };
-      expect(() => Appointment.fromMap(invalidDate), throwsA(isA<FormatException>()));
+      expect(
+        () => Appointment.fromMap(invalidDate),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 
@@ -67,11 +50,9 @@ void main() {
     test('appointments with the same values are equal', () {
       const uuid = Uuid();
       final id = uuid.v4();
-      final clientId = uuid.v4();
       final providerId = uuid.v4();
       final a1 = Appointment(
         id: id,
-        clientId: clientId,
         providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
@@ -79,40 +60,12 @@ void main() {
       );
       final a2 = Appointment(
         id: id,
-        clientId: clientId,
         providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
         duration: const Duration(hours: 1),
       );
 
-      expect(a1, equals(a2));
-      expect(a1.hashCode, equals(a2.hashCode));
-    });
-
-    test('appointments with same guest values are equal', () {
-      const uuid = Uuid();
-      final dt = DateTime(2023, 9, 10, 10, 0);
-      final id = uuid.v4();
-      final providerId = uuid.v4();
-      final a1 = Appointment(
-        id: id,
-        guestName: 'Walk-in',
-        guestContact: '555',
-        providerId: providerId,
-        service: ServiceType.barber,
-        dateTime: dt,
-        duration: const Duration(hours: 1),
-      );
-      final a2 = Appointment(
-        id: id,
-        guestName: 'Walk-in',
-        guestContact: '555',
-        providerId: providerId,
-        service: ServiceType.barber,
-        dateTime: dt,
-        duration: const Duration(hours: 1),
-      );
       expect(a1, equals(a2));
       expect(a1.hashCode, equals(a2.hashCode));
     });
@@ -121,11 +74,9 @@ void main() {
       const uuid = Uuid();
       final id1 = uuid.v4();
       final id2 = uuid.v4();
-      final clientId = uuid.v4();
       final providerId = uuid.v4();
       final a1 = Appointment(
         id: id1,
-        clientId: clientId,
         providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
@@ -133,7 +84,6 @@ void main() {
       );
       final a2 = Appointment(
         id: id2,
-        clientId: clientId,
         providerId: providerId,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),

--- a/test/screens/calendar_page_test.dart
+++ b/test/screens/calendar_page_test.dart
@@ -19,24 +19,16 @@ class _FakeAppointmentService extends AppointmentService {
 }
 
 void main() {
-  testWidgets('selecting a date shows appointments for that day', (tester) async {
+  testWidgets('selecting a date shows appointments for that day', (
+    tester,
+  ) async {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day, 10);
     final tomorrow = today.add(const Duration(days: 1));
 
     final service = _FakeAppointmentService([
-      Appointment(
-        id: '1',
-        service: ServiceType.barber,
-        dateTime: today,
-        guestName: 'Alice',
-      ),
-      Appointment(
-        id: '2',
-        service: ServiceType.nails,
-        dateTime: tomorrow,
-        guestName: 'Bob',
-      ),
+      Appointment(id: '1', service: ServiceType.barber, dateTime: today),
+      Appointment(id: '2', service: ServiceType.nails, dateTime: tomorrow),
     ]);
 
     await tester.pumpWidget(
@@ -52,20 +44,21 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initially shows today's appointment
-    expect(find.text('Alice - Barber'), findsOneWidget);
-    expect(find.text('Bob - Nails'), findsNothing);
+    expect(find.text('Barber - Unknown'), findsOneWidget);
+    expect(find.text('Nails - Unknown'), findsNothing);
 
     // Select tomorrow
     final calendarFinder = find.byType(TableCalendar<Appointment>);
-    final calendarWidget = tester.widget<TableCalendar<Appointment>>(calendarFinder);
+    final calendarWidget = tester.widget<TableCalendar<Appointment>>(
+      calendarFinder,
+    );
     calendarWidget.onDaySelected!(
       DateTime(tomorrow.year, tomorrow.month, tomorrow.day),
       DateTime(tomorrow.year, tomorrow.month, tomorrow.day),
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Bob - Nails'), findsOneWidget);
-    expect(find.text('Alice - Barber'), findsNothing);
+    expect(find.text('Nails - Unknown'), findsOneWidget);
+    expect(find.text('Barber - Unknown'), findsNothing);
   });
 }
-


### PR DESCRIPTION
## Summary
- drop client- and guest-related fields from `Appointment`
- update services and screens to work without client data
- remove guest form fields and refresh tests

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2f890570832b9da3538d6f82ce73