### PR TITLE
Localize appointment duration label

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -42,6 +42,7 @@
   "serviceLabel": "Service",
   "selectServiceValidation": "Please select a service",
   "selectDateButton": "Select Date",
+  "durationMinutesLabel": "Duration (minutes)",
   "invalidCredentials": "Invalid credentials",
   "emailLabel": "Email",
   "passwordLabel": "Password",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -42,6 +42,7 @@
   "serviceLabel": "Servicio",
   "selectServiceValidation": "Por favor selecciona un servicio",
   "selectDateButton": "Seleccionar fecha",
+  "durationMinutesLabel": "Duración (minutos)",
   "invalidCredentials": "Credenciales inválidas",
   "emailLabel": "Correo electrónico",
   "passwordLabel": "Contraseña",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -350,6 +350,12 @@ abstract class AppLocalizations {
   /// **'Select Date'**
   String get selectDateButton;
 
+  /// No description provided for @durationMinutesLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Duration (minutes)'**
+  String get durationMinutesLabel;
+
   /// No description provided for @invalidCredentials.
   ///
   /// In en, this message translates to:
@@ -445,7 +451,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add your first appointment'**
   String get addFirstAppointment;
-
 
   /// No description provided for @serviceTypeBarber.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -136,6 +136,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get selectDateButton => 'Select Date';
 
   @override
+  String get durationMinutesLabel => 'Duration (minutes)';
+
+  @override
   String get invalidCredentials => 'Invalid credentials';
 
   @override
@@ -184,7 +187,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addFirstAppointment => 'Add your first appointment';
 
   @override
-
   @override
   String get serviceTypeBarber => 'Barber';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -136,6 +136,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get selectDateButton => 'Seleccionar fecha';
 
   @override
+  String get durationMinutesLabel => 'Duración (minutos)';
+
+  @override
   String get invalidCredentials => 'Credenciales inválidas';
 
   @override
@@ -184,7 +187,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get addFirstAppointment => 'Agrega tu primera cita';
 
   @override
-
   @override
   String get serviceTypeBarber => 'Barbero';
 

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -27,8 +27,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   @override
   void initState() {
     super.initState();
-    _service =
-        widget.appointment?.service ??
+    _service = widget.appointment?.service ??
         widget.initialService ??
         ServiceType.barber;
     _dateTime = widget.appointment?.dateTime ?? DateTime.now();
@@ -91,8 +90,8 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               ),
               DropdownButtonFormField<int>(
                 value: _duration.inMinutes,
-                decoration: const InputDecoration(
-                  labelText: 'Duration (minutes)',
+                decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context)!.durationMinutesLabel,
                 ),
                 items: List.generate(8, (i) => (i + 1) * 15)
                     .map(


### PR DESCRIPTION
## Summary
- add `durationMinutesLabel` key for English and Spanish localizations
- expose `durationMinutesLabel` in generated localization classes
- use localized duration label in appointment editor

## Testing
- `flutter gen-l10n`
- `flutter test` *(fails: intl 0.19.0 required by flutter_localizations)*

------
https://chatgpt.com/codex/tasks/task_e_68af01a37f88832bb36985e1b391d0a0