### PR TITLE
Use localized service type labels

### DIFF
--- a/lib/widgets/service_offering_editor.dart
+++ b/lib/widgets/service_offering_editor.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../l10n/app_localizations.dart';
 import '../models/service_offering.dart';
 import '../models/service_type.dart';
+import '../utils/service_type_utils.dart';
 
 /// Editor widget for managing a list of [ServiceOffering] items.
 ///
@@ -61,7 +62,7 @@ class _ServiceOfferingEditorState extends State<ServiceOfferingEditor> {
                       .map(
                         (s) => DropdownMenuItem<ServiceType>(
                           value: s,
-                          child: Text(s.name),
+                          child: Text(serviceTypeLabel(context, s)),
                         ),
                       )
                       .toList(),

--- a/test/widgets/service_offering_editor_test.dart
+++ b/test/widgets/service_offering_editor_test.dart
@@ -57,4 +57,27 @@ void main() {
 
     expect(offerings.length, 1);
   });
+
+  testWidgets('displays localized service type labels', (tester) async {
+    var offerings = [
+      ServiceOffering(type: ServiceType.barber, name: '', price: 0),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('es'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ServiceOfferingEditor(
+            offerings: offerings,
+            onChanged: (list) => offerings = list,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Barbero'), findsOneWidget);
+    expect(find.text('barber'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary
- show localized service type labels in ServiceOfferingEditor dropdown
- test that Spanish labels appear in ServiceOfferingEditor

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68af04c2c5ec832ba98084cf1c9cc746