### PR TITLE
Add tooltip for adding users

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -32,6 +32,7 @@
   "invalidPrice": "Invalid price",
   "deleteUserFailed": "Failed to delete user",
   "cannotDeleteSelfTooltip": "Cannot delete yourself",
+  "addUserTooltip": "Add user",
   "newUserTitle": "New User",
   "editUserTitle": "Edit User",
   "adminRole": "Admin",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -32,6 +32,7 @@
   "invalidPrice": "Precio inválido",
   "deleteUserFailed": "No se pudo eliminar el usuario",
   "cannotDeleteSelfTooltip": "No puedes eliminarte a ti mismo",
+  "addUserTooltip": "Agregar usuario",
   "newUserTitle": "Nuevo usuario",
   "editUserTitle": "Editar usuario",
   "adminRole": "Administrador",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -290,6 +290,12 @@ abstract class AppLocalizations {
   /// **'Cannot delete yourself'**
   String get cannotDeleteSelfTooltip;
 
+  /// No description provided for @addUserTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Add user'**
+  String get addUserTooltip;
+
   /// No description provided for @newUserTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -106,6 +106,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cannotDeleteSelfTooltip => 'Cannot delete yourself';
 
   @override
+  String get addUserTooltip => 'Add user';
+
+  @override
   String get newUserTitle => 'New User';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -106,6 +106,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cannotDeleteSelfTooltip => 'No puedes eliminarte a ti mismo';
 
   @override
+  String get addUserTooltip => 'Agregar usuario';
+
+  @override
   String get newUserTitle => 'Nuevo usuario';
 
   @override

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -74,6 +74,7 @@ class EditUserPage extends StatelessWidget {
         },
       ),
       floatingActionButton: FloatingActionButton(
+        tooltip: AppLocalizations.of(context)!.addUserTooltip,
         onPressed: () => _showUserDialog(context),
         child: const Icon(Icons.add),
       ),


### PR DESCRIPTION
## Summary
- add tooltip to user creation FAB
- localize add-user tooltip in English and Spanish

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af05fb3954832bb8efcfeefe228c6e