### PR TITLE
feat: confirm appointment deletion

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -64,5 +64,6 @@
   "serviceTypeHairdresser": "Hairdresser",
   "serviceTypeNails": "Nails",
   "serviceTypeTattoo": "Tattoo Artist",
-  "appointmentConflict": "Appointment conflicts with existing booking"
+  "appointmentConflict": "Appointment conflicts with existing booking",
+  "deleteAppointmentTooltip": "Delete appointment"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -64,5 +64,6 @@
   "serviceTypeHairdresser": "Peluquería",
   "serviceTypeNails": "Uñas",
   "serviceTypeTattoo": "Tatuador",
-  "appointmentConflict": "La cita entra en conflicto con una reserva existente"
+  "appointmentConflict": "La cita entra en conflicto con una reserva existente",
+  "deleteAppointmentTooltip": "Eliminar cita"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -487,6 +487,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Appointment conflicts with existing booking'**
   String get appointmentConflict;
+
+  /// No description provided for @deleteAppointmentTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete appointment'**
+  String get deleteAppointmentTooltip;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -205,4 +205,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get appointmentConflict =>
       'Appointment conflicts with existing booking';
+
+  @override
+  String get deleteAppointmentTooltip => 'Delete appointment';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -205,4 +205,7 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get appointmentConflict =>
       'La cita entra en conflicto con una reserva existente';
+
+  @override
+  String get deleteAppointmentTooltip => 'Eliminar cita';
 }

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -101,8 +101,39 @@ class AppointmentsPage extends StatelessWidget {
                   },
                   trailing: IconButton(
                     icon: const Icon(Icons.delete),
+                    tooltip:
+                        AppLocalizations.of(context)!.deleteAppointmentTooltip,
                     onPressed: () async {
-                      await service.deleteAppointment(appt.id);
+                      final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (context) {
+                          return AlertDialog(
+                            title: Text(
+                                AppLocalizations.of(context)!
+                                    .appointmentsTitle),
+                            content: Text(AppLocalizations.of(context)!
+                                .deleteAppointmentTooltip),
+                            actions: [
+                              TextButton(
+                                onPressed: () =>
+                                    Navigator.pop(context, false),
+                                child: Text(AppLocalizations.of(context)!
+                                    .cancelButton),
+                              ),
+                              TextButton(
+                                onPressed: () =>
+                                    Navigator.pop(context, true),
+                                child: Text(AppLocalizations.of(context)!
+                                    .deleteAppointmentTooltip),
+                              ),
+                            ],
+                          );
+                        },
+                      );
+
+                      if (confirm == true) {
+                        await service.deleteAppointment(appt.id);
+                      }
                     },
                   ),
                 );


### PR DESCRIPTION
## Summary
- prompt users before deleting appointments
- add localized tooltip for deletion

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af07670478832b96d176217c8721e6