### PR TITLE
Add confirmation dialog for user deletion

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -65,5 +65,6 @@
   "serviceTypeNails": "Nails",
   "serviceTypeTattoo": "Tattoo Artist",
   "appointmentConflict": "Appointment conflicts with existing booking",
+  "deleteUserTooltip": "Delete user",
   "deleteAppointmentTooltip": "Delete appointment"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -65,5 +65,6 @@
   "serviceTypeNails": "Uñas",
   "serviceTypeTattoo": "Tatuador",
   "appointmentConflict": "La cita entra en conflicto con una reserva existente",
+  "deleteUserTooltip": "Eliminar usuario",
   "deleteAppointmentTooltip": "Eliminar cita"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -284,6 +284,12 @@ abstract class AppLocalizations {
   /// **'Failed to delete user'**
   String get deleteUserFailed;
 
+  /// No description provided for @deleteUserTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete user'**
+  String get deleteUserTooltip;
+
   /// No description provided for @cannotDeleteSelfTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -103,6 +103,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteUserFailed => 'Failed to delete user';
 
   @override
+  String get deleteUserTooltip => 'Delete user';
+
+  @override
   String get cannotDeleteSelfTooltip => 'Cannot delete yourself';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -103,6 +103,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteUserFailed => 'No se pudo eliminar el usuario';
 
   @override
+  String get deleteUserTooltip => 'Eliminar usuario';
+
+  @override
   String get cannotDeleteSelfTooltip => 'No puedes eliminarte a ti mismo';
 
   @override

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -53,7 +53,34 @@ class EditUserPage extends StatelessWidget {
             onTap: () => _showUserDialog(context, user: user),
             trailing: IconButton(
               icon: const Icon(Icons.delete),
+              tooltip: AppLocalizations.of(context)!.deleteUserTooltip,
               onPressed: () async {
+                final confirm = await showDialog<bool>(
+                  context: context,
+                  builder: (context) {
+                    return AlertDialog(
+                      title: Text(
+                          AppLocalizations.of(context)!.professionalsTooltip),
+                      content: Text(
+                          AppLocalizations.of(context)!.deleteUserTooltip),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: Text(
+                              AppLocalizations.of(context)!.cancelButton),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: Text(AppLocalizations.of(context)!
+                              .deleteUserTooltip),
+                        ),
+                      ],
+                    );
+                  },
+                );
+
+                if (confirm != true) return;
+
                 try {
                   await auth.deleteUser(user.id);
                   await service.deleteUser(user.id);

--- a/test/screens/edit_user_page_test.dart
+++ b/test/screens/edit_user_page_test.dart
@@ -10,9 +10,11 @@ import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/models/user_role.dart';
 
 class _FakeAppointmentService extends AppointmentService {
-  _FakeAppointmentService([this._users = const []]);
+  _FakeAppointmentService([List<UserProfile> users = const []])
+      : _users = List<UserProfile>.from(users);
 
   final List<UserProfile> _users;
+  String? deletedId;
 
   @override
   List<UserProfile> get users => _users;
@@ -25,11 +27,25 @@ class _FakeAppointmentService extends AppointmentService {
       return null;
     }
   }
+
+  @override
+  Future<void> deleteUser(String id, {String? reassignedUserId}) async {
+    deletedId = id;
+    _users.removeWhere((u) => u.id == id);
+    notifyListeners();
+  }
 }
 
 class _FakeAuthService extends AuthService {
+  bool deleted = false;
+
   @override
   String? get currentUser => 'test';
+
+  @override
+  Future<void> deleteUser(String email) async {
+    deleted = true;
+  }
 }
 
 void main() {
@@ -88,5 +104,51 @@ void main() {
 
     expect(find.text('Test User'), findsNothing);
     expect(find.widgetWithIcon(IconButton, Icons.delete), findsNothing);
+  });
+
+  testWidgets('delete requires confirmation', (tester) async {
+    final auth = _FakeAuthService();
+    final user = UserProfile(
+      id: 'other',
+      firstName: 'Other',
+      lastName: 'User',
+      roles: {UserRole.professional},
+    );
+    final service = _FakeAppointmentService([user]);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AppointmentService>.value(value: service),
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: EditUserPage(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.text('Other User'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Delete user'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Other User'), findsNothing);
+    expect(service.deletedId, 'other');
+    expect(auth.deleted, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- prompt for confirmation before deleting a user in edit user page
- localize delete tooltip
- test delete confirmation flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0870545c832bbb48eda0885fd87c