### PR TITLE
Allow guest appointments

### DIFF
--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -176,6 +176,13 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
               TextFormField(
                 controller: _guestController,
                 decoration: const InputDecoration(labelText: 'Guest name'),
+                validator: (_) {
+                  if ((_customerId == null || _customerId!.isEmpty) &&
+                      _guestController.text.isEmpty) {
+                    return 'Please select a customer or enter a guest name';
+                  }
+                  return null;
+                },
                 onChanged: (_) {
                   setState(() {
                     _customerId = null;

--- a/test/screens/edit_appointment_page_test.dart
+++ b/test/screens/edit_appointment_page_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/customer.dart';
+import 'package:vogue_vault/screens/edit_appointment_page.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/models/address.dart';
+
+class _FakeAppointmentService extends AppointmentService {
+  Appointment? added;
+  final List<Customer> _customers;
+  final List<Address> _addresses;
+
+  _FakeAppointmentService({
+    List<Customer> customers = const [],
+    List<Address> addresses = const [],
+  })  : _customers = customers,
+        _addresses = addresses;
+
+  @override
+  List<Customer> get customers => _customers;
+
+  @override
+  List<Address> get addresses => _addresses;
+
+  @override
+  Future<void> addAppointment(Appointment appointment) async {
+    added = appointment;
+  }
+}
+
+void main() {
+  testWidgets('saving with guest name stores guest appointment', (tester) async {
+    final service = _FakeAppointmentService();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppointmentService>.value(
+        value: service,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: EditAppointmentPage()),
+        ),
+      ),
+    );
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Guest name'), 'Walk-in');
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(service.added, isNotNull);
+    expect(service.added!.guestName, 'Walk-in');
+    expect(service.added!.customerId, isNull);
+  });
+}

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -155,6 +155,27 @@ void main() {
     expect(stored.location, 'Studio');
   });
 
+  test('guest appointments do not create customers', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    const uuid = Uuid();
+    final id = uuid.v4();
+    final appt = Appointment(
+      id: id,
+      guestName: 'Walk-in',
+      service: ServiceType.barber,
+      dateTime: DateTime.parse('2023-01-01'),
+      duration: const Duration(hours: 1),
+    );
+    await service.addAppointment(appt);
+
+    final stored = service.getAppointment(id)!;
+    expect(stored.guestName, 'Walk-in');
+    expect(stored.customerId, isNull);
+    expect(service.customers, isEmpty);
+  });
+
   test('address CRUD operations', () async {
     final service = AppointmentService();
     await service.init();


### PR DESCRIPTION
## Summary
- require either an existing customer selection or a guest name when editing appointments
- ensure appointments with guest names don't create customer records
- add tests for saving guest appointments and service guest handling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2184cf58832ba72c7cb10a20aa4c