### PR TITLE
Add notification reminders for appointments

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,13 +11,17 @@ import 'utils/color_palette.dart';
 import 'screens/auth_page.dart';
 import 'services/appointment_service.dart';
 import 'services/auth_service.dart';
+import 'services/notification_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Hive.initFlutter();
 
-  final appointmentService = AppointmentService();
+  final notificationService = NotificationService();
+  await notificationService.init();
+  final appointmentService =
+      AppointmentService(notificationService: notificationService);
   await appointmentService.init();
   final authService = AuthService();
   await authService.init();
@@ -30,6 +34,9 @@ Future<void> main() async {
         ),
         ChangeNotifierProvider<AuthService>.value(
           value: authService,
+        ),
+        Provider<NotificationService>.value(
+          value: notificationService,
         ),
       ],
       child: const MyApp(),

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -7,6 +7,7 @@ import '../models/user_profile.dart';
 import '../models/user_role.dart';
 import '../models/customer.dart';
 import '../models/address.dart';
+import 'notification_service.dart';
 
 class AppointmentService extends ChangeNotifier {
   static const _appointmentsBoxName = 'appointments';
@@ -21,9 +22,13 @@ class AppointmentService extends ChangeNotifier {
   late Box _usersBox;
   late Box _customersBox;
   late Box _addressesBox;
+  final NotificationService? _notificationService;
 
   bool _initialized = false;
   bool get isInitialized => _initialized;
+
+  AppointmentService({NotificationService? notificationService})
+      : _notificationService = notificationService;
 
   Future<void> init() async {
     _appointmentsBox = await Hive.openBox(_appointmentsBoxName);
@@ -227,6 +232,7 @@ class AppointmentService extends ChangeNotifier {
     }
     // providerId is persisted via the appointment's toMap representation.
     await _appointmentsBox.put(appointment.id, appointment.toMap());
+    await _notificationService?.scheduleAppointmentReminder(appointment);
     notifyListeners();
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/appointment.dart';
+
+class NotificationService {
+  static const _settingsBoxName = 'settings';
+  static const _reminderOffsetKey = 'reminderOffsetMinutes';
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  late Box _settingsBox;
+  bool _initialized = false;
+
+  NotificationService({FlutterLocalNotificationsPlugin? plugin})
+      : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    _settingsBox = await Hive.openBox(_settingsBoxName);
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosInit = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: androidInit, iOS: iosInit);
+    await _plugin.initialize(settings);
+    _initialized = true;
+  }
+
+  void _ensureInitialized() {
+    if (!_initialized) {
+      throw StateError('NotificationService has not been initialized.');
+    }
+  }
+
+  Duration get reminderOffset {
+    final minutes =
+        (_settingsBox.get(_reminderOffsetKey, defaultValue: 30) as int?) ?? 30;
+    return Duration(minutes: minutes);
+  }
+
+  Future<void> setReminderOffset(Duration offset) async {
+    _ensureInitialized();
+    await _settingsBox.put(_reminderOffsetKey, offset.inMinutes);
+  }
+
+  Future<void> scheduleAppointmentReminder(Appointment appointment) async {
+    _ensureInitialized();
+    final scheduled = appointment.dateTime.subtract(reminderOffset);
+    if (scheduled.isBefore(DateTime.now())) return;
+    await _plugin.schedule(
+      appointment.id.hashCode,
+      'Appointment Reminder',
+      'Upcoming ${appointment.service.name} appointment',
+      scheduled,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('appointments', 'Appointments'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   flutter_gen: ^5.9.0
   uuid: ^4.5.1
   table_calendar: ^3.0.9
+  flutter_local_notifications: ^16.3.2
 
 dev_dependencies:
   flutter_test:

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:mockito/mockito.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import 'package:vogue_vault/services/notification_service.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/service_type.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async =>
+      Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async =>
+      Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+class _MockNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('schedules appointment using default offset', () async {
+    final plugin = _MockNotificationsPlugin();
+    when(plugin.initialize(any)).thenAnswer((_) async {});
+    DateTime? scheduled;
+    when(plugin.schedule(
+      any,
+      any,
+      any,
+      any,
+      any,
+      androidAllowWhileIdle: anyNamed('androidAllowWhileIdle'),
+    )).thenAnswer((invocation) async {
+      scheduled = invocation.positionalArguments[3] as DateTime;
+    });
+
+    final service = NotificationService(plugin: plugin);
+    await service.init();
+
+    final appt = Appointment(
+      id: '1',
+      service: ServiceType.barber,
+      dateTime: DateTime.now().add(const Duration(hours: 2)),
+      duration: const Duration(hours: 1),
+    );
+    await service.scheduleAppointmentReminder(appt);
+
+    final expected = appt.dateTime.subtract(const Duration(minutes: 30));
+    expect(scheduled, expected);
+    verify(plugin.schedule(
+      any,
+      any,
+      any,
+      any,
+      any,
+      androidAllowWhileIdle: true,
+    )).called(1);
+  });
+
+  test('respects custom reminder offset', () async {
+    final plugin = _MockNotificationsPlugin();
+    when(plugin.initialize(any)).thenAnswer((_) async {});
+    DateTime? scheduled;
+    when(plugin.schedule(
+      any,
+      any,
+      any,
+      any,
+      any,
+      androidAllowWhileIdle: anyNamed('androidAllowWhileIdle'),
+    )).thenAnswer((invocation) async {
+      scheduled = invocation.positionalArguments[3] as DateTime;
+    });
+
+    final service = NotificationService(plugin: plugin);
+    await service.init();
+    await service.setReminderOffset(const Duration(minutes: 10));
+
+    final appt = Appointment(
+      id: '2',
+      service: ServiceType.hairdresser,
+      dateTime: DateTime.now().add(const Duration(hours: 1)),
+      duration: const Duration(hours: 1),
+    );
+    await service.scheduleAppointmentReminder(appt);
+
+    final expected = appt.dateTime.subtract(const Duration(minutes: 10));
+    expect(scheduled, expected);
+  });
+}


### PR DESCRIPTION
## Summary
- add `flutter_local_notifications` dependency
- create notification service with customizable reminder offset
- schedule reminders when appointments are added
- expose notification service through provider and add tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af23b04eac832bab29eb7236aef2ca