### PR TITLE
Add notification settings page for reminder timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ View all scheduled appointments in a calendar format.
 
 Receive notifications and reminders for upcoming services.
 
-Fully customizable notification settings.
+Choose how far in advance reminders arrive from My Business > Notification Settings.
 
 Service Catalog
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -68,4 +68,14 @@
   "appointmentConflict": "Appointment conflicts with existing booking",
   "deleteUserTooltip": "Delete user",
   "deleteAppointmentTooltip": "Delete appointment"
+  ,"notificationSettingsTitle": "Notification Settings",
+  "minutesBefore": "{minutes} minutes before",
+  "@minutesBefore": {
+    "description": "Label for reminder offset",
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -68,4 +68,14 @@
   "appointmentConflict": "La cita entra en conflicto con una reserva existente",
   "deleteUserTooltip": "Eliminar usuario",
   "deleteAppointmentTooltip": "Eliminar cita"
+  ,"notificationSettingsTitle": "Configuración de notificaciones",
+  "minutesBefore": "{minutes} minutos antes",
+  "@minutesBefore": {
+    "description": "Etiqueta para el tiempo de recordatorio",
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -505,6 +505,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Delete appointment'**
   String get deleteAppointmentTooltip;
+
+  /// No description provided for @notificationSettingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notification Settings'**
+  String get notificationSettingsTitle;
+
+  /// No description provided for @minutesBefore.
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes} minutes before'**
+  String minutesBefore(int minutes);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -214,4 +214,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deleteAppointmentTooltip => 'Delete appointment';
+
+  @override
+  String get notificationSettingsTitle => 'Notification Settings';
+
+  @override
+  String minutesBefore(int minutes) {
+    return minutes.toString() + ' minutes before';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -214,4 +214,12 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get deleteAppointmentTooltip => 'Eliminar cita';
+
+  @override
+  String get notificationSettingsTitle => 'Configuración de notificaciones';
+
+  @override
+  String minutesBefore(int minutes) {
+    return minutes.toString() + ' minutos antes';
+  }
 }

--- a/lib/screens/my_business_page.dart
+++ b/lib/screens/my_business_page.dart
@@ -3,6 +3,7 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import 'customers_page.dart';
 import 'addresses_page.dart';
+import 'notification_settings_page.dart';
 
 class MyBusinessPage extends StatelessWidget {
   const MyBusinessPage({super.key});
@@ -32,6 +33,17 @@ class MyBusinessPage extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const AddressesPage()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.notifications),
+            title: Text(AppLocalizations.of(context)!.notificationSettingsTitle),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const NotificationSettingsPage()),
               );
             },
           ),

--- a/lib/screens/notification_settings_page.dart
+++ b/lib/screens/notification_settings_page.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
+
+import '../services/notification_service.dart';
+
+class NotificationSettingsPage extends StatefulWidget {
+  const NotificationSettingsPage({super.key});
+
+  @override
+  State<NotificationSettingsPage> createState() => _NotificationSettingsPageState();
+}
+
+class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
+  final List<Duration> _options = const [
+    Duration(minutes: 5),
+    Duration(minutes: 10),
+    Duration(minutes: 15),
+    Duration(minutes: 30),
+    Duration(minutes: 60),
+  ];
+
+  late Duration _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    final service = context.read<NotificationService>();
+    _selected = service.reminderOffset;
+  }
+
+  Future<void> _save() async {
+    final service = context.read<NotificationService>();
+    await service.setReminderOffset(_selected);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(AppLocalizations.of(context)!.changesSaved)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.notificationSettingsTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                children: _options
+                    .map(
+                      (d) => RadioListTile<Duration>(
+                        title: Text(l10n.minutesBefore(d.inMinutes)),
+                        value: d,
+                        groupValue: _selected,
+                        onChanged: (value) {
+                          if (value != null) {
+                            setState(() => _selected = value);
+                          }
+                        },
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _save,
+                child: Text(l10n.saveButton),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add notification settings screen to select appointment reminder timing
- wire selection to NotificationService and expose from My Business page
- localize new strings and document how to change reminder timing

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ae24a88832b8670c9f53cb922c4