### PR TITLE
feat: use zoned scheduling for reminders

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   uuid: ^4.5.1
   table_calendar: ^3.0.9
   flutter_local_notifications: ^16.3.2
+  timezone: ^0.9.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace deprecated notification `schedule` with timezone-aware `zonedSchedule`
- add timezone initialization and dependency
- update tests to validate zoned scheduling

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af408605e8832b8a54c04631f299cc