### PR TITLE
Allow adding multiple addresses to customers

### DIFF
--- a/lib/models/customer.dart
+++ b/lib/models/customer.dart
@@ -1,3 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+import 'address.dart';
+
 /// Represents a customer of the professional.
 class Customer {
   /// Unique identifier for the customer.
@@ -12,11 +16,15 @@ class Customer {
   /// Optional contact information such as phone or email.
   final String? contactInfo;
 
+  /// Addresses associated with the customer.
+  final List<Address> addresses;
+
   const Customer({
     required this.id,
     required this.firstName,
     required this.lastName,
     this.contactInfo,
+    this.addresses = const [],
   });
 
   /// Convenience full name getter.
@@ -29,6 +37,11 @@ class Customer {
       firstName: map['firstName'] as String,
       lastName: map['lastName'] as String,
       contactInfo: map['contactInfo'] as String?,
+      addresses: (map['addresses'] as List?)
+              ?.map((e) =>
+                  Address.fromMap(Map<String, dynamic>.from(e as Map)))
+              .toList() ??
+          const [],
     );
   }
 
@@ -39,6 +52,7 @@ class Customer {
       'firstName': firstName,
       'lastName': lastName,
       'contactInfo': contactInfo,
+      'addresses': addresses.map((a) => a.toMap()).toList(),
     };
   }
 
@@ -47,12 +61,14 @@ class Customer {
     String? firstName,
     String? lastName,
     String? contactInfo,
+    List<Address>? addresses,
   }) {
     return Customer(
       id: id ?? this.id,
       firstName: firstName ?? this.firstName,
       lastName: lastName ?? this.lastName,
       contactInfo: contactInfo ?? this.contactInfo,
+      addresses: addresses ?? this.addresses,
     );
   }
 
@@ -64,13 +80,15 @@ class Customer {
           id == other.id &&
           firstName == other.firstName &&
           lastName == other.lastName &&
-          contactInfo == other.contactInfo;
+          contactInfo == other.contactInfo &&
+          listEquals(addresses, other.addresses);
 
   @override
   int get hashCode =>
       id.hashCode ^
       firstName.hashCode ^
       lastName.hashCode ^
-      contactInfo.hashCode;
+      contactInfo.hashCode ^
+      addresses.hashCode;
 }
 

--- a/lib/screens/customers_page.dart
+++ b/lib/screens/customers_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
+import '../models/address.dart';
 import '../models/customer.dart';
 import '../services/appointment_service.dart';
 
@@ -53,77 +54,150 @@ class CustomersPage extends StatelessWidget {
     final contactController =
         TextEditingController(text: customer?.contactInfo ?? '');
     final formKey = GlobalKey<FormState>();
+    final addressesData = (customer?.addresses ?? [])
+        .map((a) => {
+              'id': a.id,
+              'label': TextEditingController(text: a.label),
+              'details': TextEditingController(text: a.details),
+            })
+        .toList();
 
     try {
       await showDialog(
         context: context,
         builder: (_) {
-          return AlertDialog(
-            title: Text(customer == null
-                ? AppLocalizations.of(context)!.newCustomerTitle
-                : AppLocalizations.of(context)!.editCustomerTitle),
-            content: Form(
-              key: formKey,
-              child: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    TextFormField(
-                      controller: firstNameController,
-                      decoration: InputDecoration(
-                          labelText:
-                              AppLocalizations.of(context)!.firstNameLabel),
-                      validator: (value) => value == null || value.trim().isEmpty
-                          ? AppLocalizations.of(context)!.firstNameRequired
-                          : null,
+          return StatefulBuilder(
+            builder: (context, setState) {
+              return AlertDialog(
+                title: Text(customer == null
+                    ? AppLocalizations.of(context)!.newCustomerTitle
+                    : AppLocalizations.of(context)!.editCustomerTitle),
+                content: Form(
+                  key: formKey,
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        TextFormField(
+                          controller: firstNameController,
+                          decoration: InputDecoration(
+                              labelText:
+                                  AppLocalizations.of(context)!.firstNameLabel),
+                          validator: (value) =>
+                              value == null || value.trim().isEmpty
+                                  ? AppLocalizations.of(context)!
+                                      .firstNameRequired
+                                  : null,
+                        ),
+                        TextFormField(
+                          controller: lastNameController,
+                          decoration: InputDecoration(
+                              labelText:
+                                  AppLocalizations.of(context)!.lastNameLabel),
+                          validator: (value) =>
+                              value == null || value.trim().isEmpty
+                                  ? AppLocalizations.of(context)!
+                                      .lastNameRequired
+                                  : null,
+                        ),
+                        TextFormField(
+                          controller: contactController,
+                          decoration: InputDecoration(
+                              labelText:
+                                  AppLocalizations.of(context)!
+                                      .contactInfoLabel),
+                        ),
+                        for (var i = 0; i < addressesData.length; i++) ...[
+                          TextFormField(
+                            controller: addressesData[i]['label']
+                                as TextEditingController,
+                            decoration:
+                                const InputDecoration(labelText: 'Label'),
+                          ),
+                          TextFormField(
+                            controller: addressesData[i]['details']
+                                as TextEditingController,
+                            decoration:
+                                const InputDecoration(labelText: 'Address'),
+                          ),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: IconButton(
+                              icon: const Icon(Icons.delete),
+                              onPressed: () {
+                                final data = addressesData.removeAt(i);
+                                (data['label'] as TextEditingController)
+                                    .dispose();
+                                (data['details'] as TextEditingController)
+                                    .dispose();
+                                setState(() {});
+                              },
+                            ),
+                          ),
+                        ],
+                        TextButton.icon(
+                          onPressed: () {
+                            setState(() {
+                              addressesData.add({
+                                'id': const Uuid().v4(),
+                                'label': TextEditingController(),
+                                'details': TextEditingController(),
+                              });
+                            });
+                          },
+                          icon: const Icon(Icons.add),
+                          label: const Text('Add Address'),
+                        ),
+                      ],
                     ),
-                    TextFormField(
-                      controller: lastNameController,
-                      decoration: InputDecoration(
-                          labelText:
-                              AppLocalizations.of(context)!.lastNameLabel),
-                      validator: (value) => value == null || value.trim().isEmpty
-                          ? AppLocalizations.of(context)!.lastNameRequired
-                          : null,
-                    ),
-                    TextFormField(
-                      controller: contactController,
-                      decoration: InputDecoration(
-                          labelText:
-                              AppLocalizations.of(context)!.contactInfoLabel),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text(AppLocalizations.of(context)!.cancelButton),
-              ),
-              TextButton(
-                onPressed: () async {
-                  if (!formKey.currentState!.validate()) return;
-                  final service = context.read<AppointmentService>();
-                  final id = customer?.id ?? const Uuid().v4();
-                  final newCustomer = Customer(
-                    id: id,
-                    firstName: firstNameController.text.trim(),
-                    lastName: lastNameController.text.trim(),
-                    contactInfo: contactController.text.trim().isEmpty
-                        ? null
-                        : contactController.text.trim(),
-                  );
-                  if (customer == null) {
-                    await service.addCustomer(newCustomer);
-                  } else {
-                    await service.updateCustomer(newCustomer);
-                  }
-                  if (context.mounted) Navigator.pop(context);
-                },
-                child: Text(AppLocalizations.of(context)!.saveButton),
-              ),
-            ],
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child:
+                        Text(AppLocalizations.of(context)!.cancelButton),
+                  ),
+                  TextButton(
+                    onPressed: () async {
+                      if (!formKey.currentState!.validate()) return;
+                      final service = context.read<AppointmentService>();
+                      final id = customer?.id ?? const Uuid().v4();
+                      final addresses = addressesData
+                          .map((data) => Address(
+                                id: data['id'] as String,
+                                label: (data['label'] as TextEditingController)
+                                    .text
+                                    .trim(),
+                                details:
+                                    (data['details'] as TextEditingController)
+                                        .text
+                                        .trim(),
+                              ))
+                          .where((a) =>
+                              a.label.isNotEmpty && a.details.isNotEmpty)
+                          .toList();
+                      final newCustomer = Customer(
+                        id: id,
+                        firstName: firstNameController.text.trim(),
+                        lastName: lastNameController.text.trim(),
+                        contactInfo: contactController.text.trim().isEmpty
+                            ? null
+                            : contactController.text.trim(),
+                        addresses: addresses,
+                      );
+                      if (customer == null) {
+                        await service.addCustomer(newCustomer);
+                      } else {
+                        await service.updateCustomer(newCustomer);
+                      }
+                      if (context.mounted) Navigator.pop(context);
+                    },
+                    child: Text(AppLocalizations.of(context)!.saveButton),
+                  ),
+                ],
+              );
+            },
           );
         },
       );
@@ -131,6 +205,10 @@ class CustomersPage extends StatelessWidget {
       firstNameController.dispose();
       lastNameController.dispose();
       contactController.dispose();
+      for (final data in addressesData) {
+        (data['label'] as TextEditingController).dispose();
+        (data['details'] as TextEditingController).dispose();
+      }
     }
   }
 }

--- a/test/models/customer_test.dart
+++ b/test/models/customer_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:vogue_vault/models/customer.dart';
+import 'package:vogue_vault/models/address.dart';
+
+void main() {
+  test('toMap and fromMap include addresses', () {
+    const address = Address(id: 'a', label: 'Home', details: '123 Main');
+    const customer = Customer(
+      id: '1',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      contactInfo: 'jane@example.com',
+      addresses: [address],
+    );
+    final map = customer.toMap();
+    final fromMap = Customer.fromMap(map);
+    expect(fromMap, customer);
+  });
+}


### PR DESCRIPTION
## Summary
- support persisting addresses on Customer model
- allow adding/removing multiple addresses in customer dialog
- cover Customer address mapping with new test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68af692d86dc832baa7a6580227f5026