### PR TITLE
Sync customer addresses with global list

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -178,12 +178,20 @@ class AppointmentService extends ChangeNotifier {
   Future<void> addCustomer(Customer customer) async {
     _ensureInitialized();
     await _customersBox.put(customer.id, customer.toMap());
+    // Ensure customer addresses are also available in the global addresses box
+    for (final address in customer.addresses) {
+      await _addressesBox.put(address.id, address.toMap());
+    }
     notifyListeners();
   }
 
   Future<void> updateCustomer(Customer customer) async {
     _ensureInitialized();
     await _customersBox.put(customer.id, customer.toMap());
+    // Keep global addresses in sync with any updates to the customer's addresses
+    for (final address in customer.addresses) {
+      await _addressesBox.put(address.id, address.toMap());
+    }
     notifyListeners();
   }
 

--- a/test/services/appointment_service_test.dart
+++ b/test/services/appointment_service_test.dart
@@ -12,6 +12,7 @@ import 'package:vogue_vault/models/user_profile.dart';
 import 'package:vogue_vault/models/service_offering.dart';
 import 'package:vogue_vault/models/user_role.dart';
 import 'package:vogue_vault/models/address.dart';
+import 'package:vogue_vault/models/customer.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   @override
@@ -174,6 +175,23 @@ void main() {
     expect(stored.guestName, 'Walk-in');
     expect(stored.customerId, isNull);
     expect(service.customers, isEmpty);
+  });
+
+  test('customer addresses are stored globally', () async {
+    final service = AppointmentService();
+    await service.init();
+
+    const uuid = Uuid();
+    final address = Address(id: uuid.v4(), label: 'Home', details: '123 Main');
+    final customer = Customer(
+      id: uuid.v4(),
+      firstName: 'John',
+      lastName: 'Doe',
+      addresses: [address],
+    );
+
+    await service.addCustomer(customer);
+    expect(service.addresses, contains(address));
   });
 
   test('address CRUD operations', () async {


### PR DESCRIPTION
## Summary
- Sync customer addresses with the global addresses box so saved addresses appear in the Addresses tab
- Cover global address sync with a new unit test

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68af6f7a2ed4832b92a8e4af73e7b622