### PR TITLE
feat: allow selecting saved addresses for customers

### DIFF
--- a/lib/screens/customers_page.dart
+++ b/lib/screens/customers_page.dart
@@ -47,6 +47,7 @@ class CustomersPage extends StatelessWidget {
 
   Future<void> _showCustomerDialog(BuildContext context,
       {Customer? customer}) async {
+    final service = context.read<AppointmentService>();
     final firstNameController =
         TextEditingController(text: customer?.firstName ?? '');
     final lastNameController =
@@ -59,6 +60,8 @@ class CustomersPage extends StatelessWidget {
               'id': a.id,
               'label': TextEditingController(text: a.label),
               'details': TextEditingController(text: a.details),
+              'selectedId':
+                  service.addresses.any((addr) => addr.id == a.id) ? a.id : null,
             })
         .toList();
 
@@ -108,6 +111,35 @@ class CustomersPage extends StatelessWidget {
                                       .contactInfoLabel),
                         ),
                         for (var i = 0; i < addressesData.length; i++) ...[
+                          DropdownButtonFormField<String>(
+                            value: addressesData[i]['selectedId'] as String?,
+                            decoration:
+                                const InputDecoration(labelText: 'Saved address'),
+                            items: service.addresses
+                                .map(
+                                  (a) => DropdownMenuItem<String>(
+                                    value: a.id,
+                                    child: Text(a.label),
+                                  ),
+                                )
+                                .toList(),
+                            onChanged: (value) {
+                              setState(() {
+                                addressesData[i]['selectedId'] = value;
+                                if (value != null) {
+                                  final addr = service.addresses
+                                      .firstWhere((a) => a.id == value);
+                                  (addressesData[i]['label']
+                                          as TextEditingController)
+                                      .text = addr.label;
+                                  (addressesData[i]['details']
+                                          as TextEditingController)
+                                      .text = addr.details;
+                                  addressesData[i]['id'] = addr.id;
+                                }
+                              });
+                            },
+                          ),
                           TextFormField(
                             controller: addressesData[i]['label']
                                 as TextEditingController,
@@ -142,6 +174,7 @@ class CustomersPage extends StatelessWidget {
                                 'id': const Uuid().v4(),
                                 'label': TextEditingController(),
                                 'details': TextEditingController(),
+                                'selectedId': null,
                               });
                             });
                           },

--- a/test/widgets/customer_address_selection_test.dart
+++ b/test/widgets/customer_address_selection_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/address.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/screens/customers_page.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  testWidgets('saved addresses appear when editing customer', (tester) async {
+    final service = AppointmentService();
+    await service.init();
+    final address = Address(id: '1', label: 'Studio', details: '123 Main');
+    await service.addAddress(address);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppointmentService>.value(
+        value: service,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: CustomersPage()),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Add Address'));
+    await tester.pump();
+
+    await tester.tap(
+        find.widgetWithText(DropdownButtonFormField<String>, 'Saved address'));
+    await tester.pumpAndSettle();
+    expect(find.text('Studio'), findsOneWidget);
+    await tester.tap(find.text('Studio'));
+    await tester.pump();
+
+    final labelField = find.widgetWithText(TextFormField, 'Label');
+    final labelText =
+        tester.widget<TextFormField>(labelField).controller!.text;
+    expect(labelText, 'Studio');
+
+    final addressField = find.widgetWithText(TextFormField, 'Address');
+    final addressText =
+        tester.widget<TextFormField>(addressField).controller!.text;
+    expect(addressText, '123 Main');
+  });
+}


### PR DESCRIPTION
## Summary
- allow choosing from saved addresses when adding or editing a customer
- test selecting a saved address fills customer fields

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afced516c0832b8c0d2e55d42a9d78