### PR TITLE
Add price field to appointments

### DIFF
--- a/lib/models/appointment.dart
+++ b/lib/models/appointment.dart
@@ -20,6 +20,9 @@ class Appointment {
   /// Location where the appointment takes place.
   final String? location;
 
+  /// Price charged for the appointment.
+  final double? price;
+
   /// The type of service being scheduled.
   final ServiceType service;
 
@@ -36,6 +39,7 @@ class Appointment {
     this.customerId,
     this.guestName,
     this.location,
+    this.price,
     required this.service,
     required this.dateTime,
     this.duration = const Duration(hours: 1),
@@ -48,6 +52,7 @@ class Appointment {
     String? customerId,
     String? guestName,
     String? location,
+    double? price,
     ServiceType? service,
     DateTime? dateTime,
     Duration? duration,
@@ -58,6 +63,7 @@ class Appointment {
       customerId: customerId ?? this.customerId,
       guestName: guestName ?? this.guestName,
       location: location ?? this.location,
+      price: price ?? this.price,
       service: service ?? this.service,
       dateTime: dateTime ?? this.dateTime,
       duration: duration ?? this.duration,
@@ -72,6 +78,7 @@ class Appointment {
       customerId: map['customerId'] as String?,
       guestName: map['guestName'] as String?,
       location: map['location'] as String?,
+      price: map['price'] == null ? null : (map['price'] as num).toDouble(),
       service: ServiceType.values.byName(map['service'] as String),
       dateTime: DateTime.parse(map['dateTime'] as String),
       duration: Duration(minutes: (map['duration'] as int?) ?? 60),
@@ -86,6 +93,7 @@ class Appointment {
       'customerId': customerId,
       'guestName': guestName,
       'location': location,
+      'price': price,
       'service': service.name,
       'dateTime': dateTime.toIso8601String(),
       'duration': duration.inMinutes,
@@ -102,6 +110,7 @@ class Appointment {
           customerId == other.customerId &&
           guestName == other.guestName &&
           location == other.location &&
+          price == other.price &&
           service == other.service &&
           dateTime == other.dateTime &&
           duration == other.duration;
@@ -113,6 +122,7 @@ class Appointment {
       customerId.hashCode ^
       guestName.hashCode ^
       location.hashCode ^
+      price.hashCode ^
       service.hashCode ^
       dateTime.hashCode ^
       duration.hashCode;

--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -89,7 +89,8 @@ class AppointmentsPage extends StatelessWidget {
                     ),
                   ),
                   title: Text(
-                    '${serviceTypeLabel(context, appt.service)} - $providerName',
+                    '${serviceTypeLabel(context, appt.service)} - $providerName'
+                    '${appt.price != null ? ' (\$${appt.price!.toStringAsFixed(2)})' : ''}',
                   ),
                   subtitle: Text(
                     '${DateFormat.yMMMd(locale).format(appt.dateTime.toLocal())} '

--- a/lib/screens/calendar_page.dart
+++ b/lib/screens/calendar_page.dart
@@ -88,7 +88,8 @@ class _CalendarPageState extends State<CalendarPage> {
                         ),
                         title: Text(
                           '${serviceTypeLabel(context, appt.service)} - '
-                          '$providerName',
+                          '$providerName'
+                          '${appt.price != null ? ' (\$${appt.price!.toStringAsFixed(2)})' : ''}',
                         ),
                         subtitle: Text(
                           '${DateFormat.jm(locale).format(appt.dateTime.toLocal())} - '

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -42,7 +42,7 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
     _customerId = widget.appointment?.customerId;
     _guestController.text = widget.appointment?.guestName ?? '';
     _locationController.text = widget.appointment?.location ?? '';
-    _priceController.text = '';
+    _priceController.text = widget.appointment?.price?.toStringAsFixed(2) ?? '';
     _addressId = null;
   }
 
@@ -280,6 +280,9 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                     location: _locationController.text.isEmpty
                         ? null
                         : _locationController.text,
+                    price: _priceController.text.isEmpty
+                        ? null
+                        : double.parse(_priceController.text),
                     service: _service,
                     dateTime: _dateTime,
                     duration: _duration,

--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -52,7 +52,8 @@ class AppointmentService extends ChangeNotifier {
       if (!map.containsKey('duration') ||
           !map.containsKey('customerId') ||
           !map.containsKey('guestName') ||
-          !map.containsKey('location')) {
+          !map.containsKey('location') ||
+          !map.containsKey('price')) {
         _appointmentsBox.put(appt.id, appt.toMap());
       }
       return appt;
@@ -120,7 +121,8 @@ class AppointmentService extends ChangeNotifier {
     if (!appointmentMap.containsKey('duration') ||
         !appointmentMap.containsKey('customerId') ||
         !appointmentMap.containsKey('guestName') ||
-        !appointmentMap.containsKey('location')) {
+        !appointmentMap.containsKey('location') ||
+        !appointmentMap.containsKey('price')) {
       _appointmentsBox.put(appt.id, appt.toMap());
     }
     return appt;

--- a/test/models/appointment_test.dart
+++ b/test/models/appointment_test.dart
@@ -13,6 +13,7 @@ void main() {
         customerId: 'c1',
         guestName: 'Guest',
         location: 'Shop',
+        price: 25.0,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
         duration: const Duration(minutes: 45),
@@ -25,6 +26,7 @@ void main() {
       expect(from.customerId, appointment.customerId);
       expect(from.guestName, appointment.guestName);
       expect(from.location, appointment.location);
+      expect(from.price, appointment.price);
       expect(from.service, appointment.service);
       expect(from.dateTime, appointment.dateTime);
       expect(from.duration, appointment.duration);
@@ -59,6 +61,7 @@ void main() {
         customerId: 'c1',
         guestName: 'Guest',
         location: 'Shop',
+        price: 20.0,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
         duration: const Duration(hours: 1),
@@ -68,6 +71,7 @@ void main() {
         customerId: 'c1',
         guestName: 'Guest',
         location: 'Shop',
+        price: 20.0,
         service: ServiceType.barber,
         dateTime: DateTime(2023, 9, 10, 10, 0),
         duration: const Duration(hours: 1),


### PR DESCRIPTION
## Summary
- add optional price field to `Appointment` with serialization
- persist price from edit page and service, migrating old records
- surface stored prices in appointment lists and calendar views

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b30dce364c832ba541285a4f21809f