### PR TITLE
Handle appointment reminder updates

### DIFF
--- a/lib/services/appointment_service.dart
+++ b/lib/services/appointment_service.dart
@@ -245,11 +245,13 @@ class AppointmentService extends ChangeNotifier {
     }
     // providerId is persisted via the appointment's toMap representation.
     await _appointmentsBox.put(appointment.id, appointment.toMap());
+    await _notificationService?.rescheduleAppointmentReminder(appointment);
     notifyListeners();
   }
 
   Future<void> deleteAppointment(String id) async {
     _ensureInitialized();
+    await _notificationService?.cancelAppointmentReminder(id);
     await _appointmentsBox.delete(id);
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- implement cancellation and rescheduling in `NotificationService`
- call reschedule and cancel from `AppointmentService` on update and delete
- add tests for reminder cancellation and rescheduling

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b44a1812f4832b801188c25420cf7b