### PR TITLE
refactor: use AppScaffold across key screens

### DIFF
--- a/lib/screens/addresses_page.dart
+++ b/lib/screens/addresses_page.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 
 import '../models/address.dart';
 import '../services/appointment_service.dart';
+import '../widgets/app_scaffold.dart';
 
 class AddressesPage extends StatelessWidget {
   const AddressesPage({super.key});
@@ -13,10 +14,8 @@ class AddressesPage extends StatelessWidget {
     final service = context.watch<AppointmentService>();
     final addresses = service.addresses;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Addresses'),
-      ),
+    return AppScaffold(
+      title: 'Addresses',
       body: ListView.builder(
         itemCount: addresses.length,
         itemBuilder: (context, index) {
@@ -42,9 +41,14 @@ class AddressesPage extends StatelessWidget {
     );
   }
 
-  Future<void> _showAddressDialog(BuildContext context, {Address? address}) async {
+  Future<void> _showAddressDialog(
+    BuildContext context, {
+    Address? address,
+  }) async {
     final labelController = TextEditingController(text: address?.label ?? '');
-    final detailsController = TextEditingController(text: address?.details ?? '');
+    final detailsController = TextEditingController(
+      text: address?.details ?? '',
+    );
     final formKey = GlobalKey<FormState>();
 
     try {
@@ -63,13 +67,17 @@ class AddressesPage extends StatelessWidget {
                       controller: labelController,
                       decoration: const InputDecoration(labelText: 'Label'),
                       validator: (value) =>
-                          value == null || value.trim().isEmpty ? 'Required' : null,
+                          value == null || value.trim().isEmpty
+                          ? 'Required'
+                          : null,
                     ),
                     TextFormField(
                       controller: detailsController,
                       decoration: const InputDecoration(labelText: 'Address'),
                       validator: (value) =>
-                          value == null || value.trim().isEmpty ? 'Required' : null,
+                          value == null || value.trim().isEmpty
+                          ? 'Required'
+                          : null,
                     ),
                   ],
                 ),
@@ -109,4 +117,3 @@ class AddressesPage extends StatelessWidget {
     }
   }
 }
-

--- a/lib/screens/customers_page.dart
+++ b/lib/screens/customers_page.dart
@@ -5,6 +5,7 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/customer.dart';
 import '../services/appointment_service.dart';
+import '../widgets/app_scaffold.dart';
 
 class CustomersPage extends StatelessWidget {
   const CustomersPage({super.key});
@@ -14,10 +15,8 @@ class CustomersPage extends StatelessWidget {
     final service = context.watch<AppointmentService>();
     final customers = service.customers;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.customersTitle),
-      ),
+    return AppScaffold(
+      title: AppLocalizations.of(context)!.customersTitle,
       body: ListView.builder(
         itemCount: customers.length,
         itemBuilder: (context, index) {
@@ -25,8 +24,9 @@ class CustomersPage extends StatelessWidget {
           return ListTile(
             leading: const CircleAvatar(child: Icon(Icons.person)),
             title: Text(customer.fullName),
-            subtitle:
-                customer.contactInfo != null ? Text(customer.contactInfo!) : null,
+            subtitle: customer.contactInfo != null
+                ? Text(customer.contactInfo!)
+                : null,
             onTap: () => _showCustomerDialog(context, customer: customer),
             trailing: IconButton(
               icon: const Icon(Icons.delete),
@@ -44,15 +44,20 @@ class CustomersPage extends StatelessWidget {
     );
   }
 
-  Future<void> _showCustomerDialog(BuildContext context,
-      {Customer? customer}) async {
+  Future<void> _showCustomerDialog(
+    BuildContext context, {
+    Customer? customer,
+  }) async {
     final service = context.read<AppointmentService>();
-    final firstNameController =
-        TextEditingController(text: customer?.firstName ?? '');
-    final lastNameController =
-        TextEditingController(text: customer?.lastName ?? '');
-    final contactController =
-        TextEditingController(text: customer?.contactInfo ?? '');
+    final firstNameController = TextEditingController(
+      text: customer?.firstName ?? '',
+    );
+    final lastNameController = TextEditingController(
+      text: customer?.lastName ?? '',
+    );
+    final contactController = TextEditingController(
+      text: customer?.contactInfo ?? '',
+    );
     final formKey = GlobalKey<FormState>();
 
     try {
@@ -62,9 +67,11 @@ class CustomersPage extends StatelessWidget {
           return StatefulBuilder(
             builder: (context, setState) {
               return AlertDialog(
-                title: Text(customer == null
-                    ? AppLocalizations.of(context)!.newCustomerTitle
-                    : AppLocalizations.of(context)!.editCustomerTitle),
+                title: Text(
+                  customer == null
+                      ? AppLocalizations.of(context)!.newCustomerTitle
+                      : AppLocalizations.of(context)!.editCustomerTitle,
+                ),
                 content: Form(
                   key: formKey,
                   child: SingleChildScrollView(
@@ -74,31 +81,34 @@ class CustomersPage extends StatelessWidget {
                         TextFormField(
                           controller: firstNameController,
                           decoration: InputDecoration(
-                              labelText:
-                                  AppLocalizations.of(context)!.firstNameLabel),
+                            labelText: AppLocalizations.of(
+                              context,
+                            )!.firstNameLabel,
+                          ),
                           validator: (value) =>
                               value == null || value.trim().isEmpty
-                                  ? AppLocalizations.of(context)!
-                                      .firstNameRequired
-                                  : null,
+                              ? AppLocalizations.of(context)!.firstNameRequired
+                              : null,
                         ),
                         TextFormField(
                           controller: lastNameController,
                           decoration: InputDecoration(
-                              labelText:
-                                  AppLocalizations.of(context)!.lastNameLabel),
+                            labelText: AppLocalizations.of(
+                              context,
+                            )!.lastNameLabel,
+                          ),
                           validator: (value) =>
                               value == null || value.trim().isEmpty
-                                  ? AppLocalizations.of(context)!
-                                      .lastNameRequired
-                                  : null,
+                              ? AppLocalizations.of(context)!.lastNameRequired
+                              : null,
                         ),
                         TextFormField(
                           controller: contactController,
                           decoration: InputDecoration(
-                              labelText:
-                                  AppLocalizations.of(context)!
-                                      .contactInfoLabel),
+                            labelText: AppLocalizations.of(
+                              context,
+                            )!.contactInfoLabel,
+                          ),
                         ),
                       ],
                     ),
@@ -107,8 +117,7 @@ class CustomersPage extends StatelessWidget {
                 actions: [
                   TextButton(
                     onPressed: () => Navigator.pop(context),
-                    child:
-                        Text(AppLocalizations.of(context)!.cancelButton),
+                    child: Text(AppLocalizations.of(context)!.cancelButton),
                   ),
                   TextButton(
                     onPressed: () async {
@@ -145,4 +154,3 @@ class CustomersPage extends StatelessWidget {
     }
   }
 }
-

--- a/lib/screens/edit_appointment_page.dart
+++ b/lib/screens/edit_appointment_page.dart
@@ -10,6 +10,7 @@ import '../models/service_type.dart';
 import '../services/appointment_service.dart';
 import '../services/auth_service.dart';
 import '../utils/service_type_utils.dart';
+import '../widgets/app_scaffold.dart';
 
 class EditAppointmentPage extends StatefulWidget {
   final Appointment? appointment;
@@ -34,7 +35,8 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
   @override
   void initState() {
     super.initState();
-    _service = widget.appointment?.service ??
+    _service =
+        widget.appointment?.service ??
         widget.initialService ??
         ServiceType.barber;
     _dateTime = widget.appointment?.dateTime ?? DateTime.now();
@@ -61,19 +63,13 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
     final locale = Localizations.localeOf(context).toString();
     final isEditing = widget.appointment != null;
     final offerings = auth.currentUser != null
-        ? service.getUser(auth.currentUser!)?.offerings ??
-            <ServiceOffering>[]
+        ? service.getUser(auth.currentUser!)?.offerings ?? <ServiceOffering>[]
         : <ServiceOffering>[];
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          isEditing
-              ? AppLocalizations.of(context)!.editAppointmentTitle
-              : AppLocalizations.of(context)!.newAppointmentTitle,
-        ),
-      ),
-      resizeToAvoidBottomInset: true,
+    return AppScaffold(
+      title: isEditing
+          ? AppLocalizations.of(context)!.editAppointmentTitle
+          : AppLocalizations.of(context)!.newAppointmentTitle,
       body: SingleChildScrollView(
         padding: EdgeInsets.only(
           left: 16,
@@ -95,7 +91,8 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                       (o) => DropdownMenuItem<ServiceOffering>(
                         value: o,
                         child: Text(
-                            '${serviceTypeLabel(context, o.type)} - ${o.name} (\$${o.price.toStringAsFixed(2)})'),
+                          '${serviceTypeLabel(context, o.type)} - ${o.name} (\$${o.price.toStringAsFixed(2)})',
+                        ),
                       ),
                     )
                     .toList(),
@@ -135,7 +132,8 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                 key: const ValueKey('priceField'),
                 controller: _priceController,
                 decoration: InputDecoration(
-                    labelText: AppLocalizations.of(context)!.priceLabel),
+                  labelText: AppLocalizations.of(context)!.priceLabel,
+                ),
                 keyboardType: TextInputType.number,
                 validator: (value) {
                   if (value == null || value.isEmpty) return null;
@@ -250,8 +248,9 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                   setState(() {
                     _addressId = value;
                     if (value != null) {
-                      final addr =
-                          service.addresses.firstWhere((a) => a.id == value);
+                      final addr = service.addresses.firstWhere(
+                        (a) => a.id == value,
+                      );
                       _locationController.text = addr.details;
                     }
                   });
@@ -275,8 +274,9 @@ class _EditAppointmentPageState extends State<EditAppointmentPage> {
                     id: id,
                     providerId: widget.appointment?.providerId,
                     customerId: _customerId,
-                    guestName:
-                        _guestController.text.isEmpty ? null : _guestController.text,
+                    guestName: _guestController.text.isEmpty
+                        ? null
+                        : _guestController.text,
                     location: _locationController.text.isEmpty
                         ? null
                         : _locationController.text,

--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -12,6 +12,7 @@ import '../services/auth_service.dart';
 import '../utils/image_picking.dart';
 import 'manage_services_page.dart';
 import 'profile_page.dart';
+import '../widgets/app_scaffold.dart';
 
 class EditUserPage extends StatelessWidget {
   const EditUserPage({super.key});
@@ -20,25 +21,24 @@ class EditUserPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
     final auth = context.watch<AuthService>();
-    final users =
-        service.users.where((u) => u.id != auth.currentUser).toList();
+    final users = service.users.where((u) => u.id != auth.currentUser).toList();
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.professionalsTooltip),
-      ),
+    return AppScaffold(
+      title: AppLocalizations.of(context)!.professionalsTooltip,
       body: ListView.builder(
         itemCount: users.length,
         itemBuilder: (context, index) {
           final user = users[index];
-          final roleText = user.roles.map((role) {
-            switch (role) {
-              case UserRole.professional:
-                return AppLocalizations.of(context)!.professionalRole;
-              case UserRole.admin:
-                return AppLocalizations.of(context)!.adminRole;
-            }
-          }).join(', ');
+          final roleText = user.roles
+              .map((role) {
+                switch (role) {
+                  case UserRole.professional:
+                    return AppLocalizations.of(context)!.professionalRole;
+                  case UserRole.admin:
+                    return AppLocalizations.of(context)!.adminRole;
+                }
+              })
+              .join(', ');
           return ListTile(
             leading: CircleAvatar(
               backgroundImage: user.photoBytes != null
@@ -60,19 +60,23 @@ class EditUserPage extends StatelessWidget {
                   builder: (context) {
                     return AlertDialog(
                       title: Text(
-                          AppLocalizations.of(context)!.professionalsTooltip),
+                        AppLocalizations.of(context)!.professionalsTooltip,
+                      ),
                       content: Text(
-                          AppLocalizations.of(context)!.deleteUserTooltip),
+                        AppLocalizations.of(context)!.deleteUserTooltip,
+                      ),
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context, false),
                           child: Text(
-                              AppLocalizations.of(context)!.cancelButton),
+                            AppLocalizations.of(context)!.cancelButton,
+                          ),
                         ),
                         TextButton(
                           onPressed: () => Navigator.pop(context, true),
-                          child: Text(AppLocalizations.of(context)!
-                              .deleteUserTooltip),
+                          child: Text(
+                            AppLocalizations.of(context)!.deleteUserTooltip,
+                          ),
                         ),
                       ],
                     );
@@ -89,11 +93,9 @@ class EditUserPage extends StatelessWidget {
                   final message = e is StateError
                       ? e.message
                       : AppLocalizations.of(context)!.deleteUserFailed;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(message),
-                    ),
-                  );
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(SnackBar(content: Text(message)));
                 }
               },
             ),
@@ -108,14 +110,19 @@ class EditUserPage extends StatelessWidget {
     );
   }
 
-  Future<void> _showUserDialog(BuildContext context,
-      {UserProfile? user}) async {
-    final firstNameController =
-        TextEditingController(text: user?.firstName ?? '');
-    final lastNameController =
-        TextEditingController(text: user?.lastName ?? '');
-    final nicknameController =
-        TextEditingController(text: user?.nickname ?? '');
+  Future<void> _showUserDialog(
+    BuildContext context, {
+    UserProfile? user,
+  }) async {
+    final firstNameController = TextEditingController(
+      text: user?.firstName ?? '',
+    );
+    final lastNameController = TextEditingController(
+      text: user?.lastName ?? '',
+    );
+    final nicknameController = TextEditingController(
+      text: user?.nickname ?? '',
+    );
     final formKey = GlobalKey<FormState>();
     Uint8List? photoBytes = user?.photoBytes;
 
@@ -125,9 +132,11 @@ class EditUserPage extends StatelessWidget {
         builder: (_) => StatefulBuilder(
           builder: (context, setState) {
             return AlertDialog(
-              title: Text(user == null
-                  ? AppLocalizations.of(context)!.newUserTitle
-                  : AppLocalizations.of(context)!.editUserTitle),
+              title: Text(
+                user == null
+                    ? AppLocalizations.of(context)!.newUserTitle
+                    : AppLocalizations.of(context)!.editUserTitle,
+              ),
               content: Form(
                 key: formKey,
                 child: SingleChildScrollView(
@@ -139,8 +148,11 @@ class EditUserPage extends StatelessWidget {
                           if (!isImagePickerSupported) {
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
-                                content: Text(AppLocalizations.of(context)!
-                                    .imageSelectionUnsupported),
+                                content: Text(
+                                  AppLocalizations.of(
+                                    context,
+                                  )!.imageSelectionUnsupported,
+                                ),
                               ),
                             );
                             return;
@@ -163,28 +175,34 @@ class EditUserPage extends StatelessWidget {
                       TextFormField(
                         controller: firstNameController,
                         decoration: InputDecoration(
-                            labelText:
-                                AppLocalizations.of(context)!.firstNameLabel),
-                        validator: (value) => value == null ||
-                                value.trim().isEmpty
+                          labelText: AppLocalizations.of(
+                            context,
+                          )!.firstNameLabel,
+                        ),
+                        validator: (value) =>
+                            value == null || value.trim().isEmpty
                             ? AppLocalizations.of(context)!.firstNameRequired
                             : null,
                       ),
                       TextFormField(
                         controller: lastNameController,
                         decoration: InputDecoration(
-                            labelText:
-                                AppLocalizations.of(context)!.lastNameLabel),
+                          labelText: AppLocalizations.of(
+                            context,
+                          )!.lastNameLabel,
+                        ),
                         validator: (value) =>
                             value == null || value.trim().isEmpty
-                                ? AppLocalizations.of(context)!.lastNameRequired
-                                : null,
+                            ? AppLocalizations.of(context)!.lastNameRequired
+                            : null,
                       ),
                       TextFormField(
                         controller: nicknameController,
                         decoration: InputDecoration(
-                            labelText:
-                                AppLocalizations.of(context)!.nicknameLabel),
+                          labelText: AppLocalizations.of(
+                            context,
+                          )!.nicknameLabel,
+                        ),
                       ),
                       Align(
                         alignment: Alignment.centerLeft,
@@ -194,9 +212,7 @@ class EditUserPage extends StatelessWidget {
                               MaterialPageRoute(
                                 builder: (_) => user == null
                                     ? const ProfilePage(isNewUser: true)
-                                    : ManageServicesPage(
-                                        userId: user.id,
-                                      ),
+                                    : ManageServicesPage(userId: user.id),
                               ),
                             );
                           },

--- a/lib/screens/my_business_page.dart
+++ b/lib/screens/my_business_page.dart
@@ -4,16 +4,15 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 import 'customers_page.dart';
 import 'addresses_page.dart';
 import 'notification_settings_page.dart';
+import '../widgets/app_scaffold.dart';
 
 class MyBusinessPage extends StatelessWidget {
   const MyBusinessPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.myBusinessTitle),
-      ),
+    return AppScaffold(
+      title: AppLocalizations.of(context)!.myBusinessTitle,
       body: ListView(
         children: [
           ListTile(
@@ -38,12 +37,15 @@ class MyBusinessPage extends StatelessWidget {
           ),
           ListTile(
             leading: const Icon(Icons.notifications),
-            title: Text(AppLocalizations.of(context)!.notificationSettingsTitle),
+            title: Text(
+              AppLocalizations.of(context)!.notificationSettingsTitle,
+            ),
             onTap: () {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (_) => const NotificationSettingsPage()),
+                  builder: (_) => const NotificationSettingsPage(),
+                ),
               );
             },
           ),
@@ -52,4 +54,3 @@ class MyBusinessPage extends StatelessWidget {
     );
   }
 }
-

--- a/lib/screens/notification_settings_page.dart
+++ b/lib/screens/notification_settings_page.dart
@@ -3,12 +3,14 @@ import 'package:provider/provider.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../services/notification_service.dart';
+import '../widgets/app_scaffold.dart';
 
 class NotificationSettingsPage extends StatefulWidget {
   const NotificationSettingsPage({super.key});
 
   @override
-  State<NotificationSettingsPage> createState() => _NotificationSettingsPageState();
+  State<NotificationSettingsPage> createState() =>
+      _NotificationSettingsPageState();
 }
 
 class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
@@ -41,8 +43,8 @@ class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n.notificationSettingsTitle)),
+    return AppScaffold(
+      title: l10n.notificationSettingsTitle,
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -78,4 +80,3 @@ class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- switch several screens to shared AppScaffold
- keep titles, actions and buttons aligned with AppScaffold

## Testing
- `flutter test` *(fails: RenderFlex overflow and missing getter 'value')*

------
https://chatgpt.com/codex/tasks/task_e_68b4db000010832bb78fe2d5c44f9c23