### PR TITLE
feat: localize addresses page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -67,8 +67,14 @@
   "serviceTypeTattoo": "Tattoo Artist",
   "appointmentConflict": "Appointment conflicts with existing booking",
   "deleteUserTooltip": "Delete user",
-  "deleteAppointmentTooltip": "Delete appointment"
-  ,"notificationSettingsTitle": "Notification Settings",
+  "deleteAppointmentTooltip": "Delete appointment",
+  "addressesTitle": "Addresses",
+  "newAddressTitle": "New Address",
+  "editAddressTitle": "Edit Address",
+  "labelLabel": "Label",
+  "addressLabel": "Address",
+  "requiredField": "Required",
+  "notificationSettingsTitle": "Notification Settings",
   "minutesBefore": "{minutes} minutes before",
   "@minutesBefore": {
     "description": "Label for reminder offset",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -67,8 +67,14 @@
   "serviceTypeTattoo": "Tatuador",
   "appointmentConflict": "La cita entra en conflicto con una reserva existente",
   "deleteUserTooltip": "Eliminar usuario",
-  "deleteAppointmentTooltip": "Eliminar cita"
-  ,"notificationSettingsTitle": "Configuración de notificaciones",
+  "deleteAppointmentTooltip": "Eliminar cita",
+  "addressesTitle": "Direcciones",
+  "newAddressTitle": "Nueva dirección",
+  "editAddressTitle": "Editar dirección",
+  "labelLabel": "Etiqueta",
+  "addressLabel": "Dirección",
+  "requiredField": "Requerido",
+  "notificationSettingsTitle": "Configuración de notificaciones",
   "minutesBefore": "{minutes} minutos antes",
   "@minutesBefore": {
     "description": "Etiqueta para el tiempo de recordatorio",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es')
+    Locale('es'),
   ];
 
   /// No description provided for @appTitle.
@@ -289,12 +289,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to delete user'**
   String get deleteUserFailed;
-
-  /// No description provided for @deleteUserTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Delete user'**
-  String get deleteUserTooltip;
 
   /// No description provided for @cannotDeleteSelfTooltip.
   ///
@@ -500,11 +494,53 @@ abstract class AppLocalizations {
   /// **'Appointment conflicts with existing booking'**
   String get appointmentConflict;
 
+  /// No description provided for @deleteUserTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete user'**
+  String get deleteUserTooltip;
+
   /// No description provided for @deleteAppointmentTooltip.
   ///
   /// In en, this message translates to:
   /// **'Delete appointment'**
   String get deleteAppointmentTooltip;
+
+  /// No description provided for @addressesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Addresses'**
+  String get addressesTitle;
+
+  /// No description provided for @newAddressTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'New Address'**
+  String get newAddressTitle;
+
+  /// No description provided for @editAddressTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Address'**
+  String get editAddressTitle;
+
+  /// No description provided for @labelLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Label'**
+  String get labelLabel;
+
+  /// No description provided for @addressLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Address'**
+  String get addressLabel;
+
+  /// No description provided for @requiredField.
+  ///
+  /// In en, this message translates to:
+  /// **'Required'**
+  String get requiredField;
 
   /// No description provided for @notificationSettingsTitle.
   ///
@@ -512,7 +548,7 @@ abstract class AppLocalizations {
   /// **'Notification Settings'**
   String get notificationSettingsTitle;
 
-  /// No description provided for @minutesBefore.
+  /// Label for reminder offset
   ///
   /// In en, this message translates to:
   /// **'{minutes} minutes before'**
@@ -546,8 +582,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -106,9 +106,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteUserFailed => 'Failed to delete user';
 
   @override
-  String get deleteUserTooltip => 'Delete user';
-
-  @override
   String get cannotDeleteSelfTooltip => 'Cannot delete yourself';
 
   @override
@@ -196,7 +193,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addFirstAppointment => 'Add your first appointment';
 
   @override
-  @override
   String get serviceTypeBarber => 'Barber';
 
   @override
@@ -213,13 +209,34 @@ class AppLocalizationsEn extends AppLocalizations {
       'Appointment conflicts with existing booking';
 
   @override
+  String get deleteUserTooltip => 'Delete user';
+
+  @override
   String get deleteAppointmentTooltip => 'Delete appointment';
+
+  @override
+  String get addressesTitle => 'Addresses';
+
+  @override
+  String get newAddressTitle => 'New Address';
+
+  @override
+  String get editAddressTitle => 'Edit Address';
+
+  @override
+  String get labelLabel => 'Label';
+
+  @override
+  String get addressLabel => 'Address';
+
+  @override
+  String get requiredField => 'Required';
 
   @override
   String get notificationSettingsTitle => 'Notification Settings';
 
   @override
   String minutesBefore(int minutes) {
-    return minutes.toString() + ' minutes before';
+    return '$minutes minutes before';
   }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -106,9 +106,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteUserFailed => 'No se pudo eliminar el usuario';
 
   @override
-  String get deleteUserTooltip => 'Eliminar usuario';
-
-  @override
   String get cannotDeleteSelfTooltip => 'No puedes eliminarte a ti mismo';
 
   @override
@@ -196,7 +193,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get addFirstAppointment => 'Agrega tu primera cita';
 
   @override
-  @override
   String get serviceTypeBarber => 'Barbero';
 
   @override
@@ -213,13 +209,34 @@ class AppLocalizationsEs extends AppLocalizations {
       'La cita entra en conflicto con una reserva existente';
 
   @override
+  String get deleteUserTooltip => 'Eliminar usuario';
+
+  @override
   String get deleteAppointmentTooltip => 'Eliminar cita';
+
+  @override
+  String get addressesTitle => 'Direcciones';
+
+  @override
+  String get newAddressTitle => 'Nueva dirección';
+
+  @override
+  String get editAddressTitle => 'Editar dirección';
+
+  @override
+  String get labelLabel => 'Etiqueta';
+
+  @override
+  String get addressLabel => 'Dirección';
+
+  @override
+  String get requiredField => 'Requerido';
 
   @override
   String get notificationSettingsTitle => 'Configuración de notificaciones';
 
   @override
   String minutesBefore(int minutes) {
-    return minutes.toString() + ' minutos antes';
+    return '$minutes minutos antes';
   }
 }

--- a/lib/screens/addresses_page.dart
+++ b/lib/screens/addresses_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:vogue_vault/l10n/app_localizations.dart';
+
 import '../models/address.dart';
 import '../services/appointment_service.dart';
 import '../widgets/app_scaffold.dart';
@@ -15,7 +17,7 @@ class AddressesPage extends StatelessWidget {
     final addresses = service.addresses;
 
     return AppScaffold(
-      title: 'Addresses',
+      title: AppLocalizations.of(context)!.addressesTitle,
       body: ListView.builder(
         itemCount: addresses.length,
         itemBuilder: (context, index) {
@@ -56,7 +58,11 @@ class AddressesPage extends StatelessWidget {
         context: context,
         builder: (_) {
           return AlertDialog(
-            title: Text(address == null ? 'New Address' : 'Edit Address'),
+            title: Text(
+              address == null
+                  ? AppLocalizations.of(context)!.newAddressTitle
+                  : AppLocalizations.of(context)!.editAddressTitle,
+            ),
             content: Form(
               key: formKey,
               child: SingleChildScrollView(
@@ -65,18 +71,22 @@ class AddressesPage extends StatelessWidget {
                   children: [
                     TextFormField(
                       controller: labelController,
-                      decoration: const InputDecoration(labelText: 'Label'),
+                      decoration: InputDecoration(
+                        labelText: AppLocalizations.of(context)!.labelLabel,
+                      ),
                       validator: (value) =>
                           value == null || value.trim().isEmpty
-                          ? 'Required'
+                          ? AppLocalizations.of(context)!.requiredField
                           : null,
                     ),
                     TextFormField(
                       controller: detailsController,
-                      decoration: const InputDecoration(labelText: 'Address'),
+                      decoration: InputDecoration(
+                        labelText: AppLocalizations.of(context)!.addressLabel,
+                      ),
                       validator: (value) =>
                           value == null || value.trim().isEmpty
-                          ? 'Required'
+                          ? AppLocalizations.of(context)!.requiredField
                           : null,
                     ),
                   ],
@@ -86,7 +96,7 @@ class AddressesPage extends StatelessWidget {
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context),
-                child: const Text('Cancel'),
+                child: Text(AppLocalizations.of(context)!.cancelButton),
               ),
               TextButton(
                 onPressed: () async {
@@ -105,7 +115,7 @@ class AddressesPage extends StatelessWidget {
                   }
                   if (context.mounted) Navigator.pop(context);
                 },
-                child: const Text('Save'),
+                child: Text(AppLocalizations.of(context)!.saveButton),
               ),
             ],
           );

--- a/lib/screens/my_business_page.dart
+++ b/lib/screens/my_business_page.dart
@@ -27,7 +27,7 @@ class MyBusinessPage extends StatelessWidget {
           ),
           ListTile(
             leading: const Icon(Icons.location_on),
-            title: const Text('Addresses'),
+            title: Text(AppLocalizations.of(context)!.addressesTitle),
             onTap: () {
               Navigator.push(
                 context,


### PR DESCRIPTION
## Summary
- localize addresses page strings and add translations
- look up localized labels in MyBusiness addresses link
- generate updated localization files

## Testing
- `flutter gen-l10n`
- `flutter test` *(fails: The argument type 'Null' can't be assigned to the parameter type 'InitializationSettings')*

------
https://chatgpt.com/codex/tasks/task_e_68b50c39d5e4832bad878739732de279