### PR TITLE
refactor: extract appointment tile widget

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:intl/intl.dart';
 import 'package:vogue_vault/l10n/app_localizations.dart';
 
 import '../models/appointment.dart';
-import '../utils/service_type_utils.dart';
 import '../services/appointment_service.dart';
 import '../widgets/app_scaffold.dart';
+import '../widgets/appointment_tile.dart';
 import 'edit_appointment_page.dart';
 import 'my_business_page.dart';
 import 'calendar_page.dart';
@@ -18,7 +17,6 @@ class AppointmentsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
     final appointments = service.appointments;
-    final locale = Localizations.localeOf(context).toString();
 
     return AppScaffold(
       title: AppLocalizations.of(context)!.appointmentsTitle,
@@ -70,45 +68,10 @@ class AppointmentsPage extends StatelessWidget {
           : ListView.builder(
               itemCount: appointments.length,
               itemBuilder: (context, index) {
-                final Appointment appt = appointments[index];
-                final providerName = appt.providerId != null
-                    ? service.getUser(appt.providerId!)?.name ??
-                          AppLocalizations.of(context)!.unknownUser
-                    : AppLocalizations.of(context)!.unknownUser;
-                final customerName = appt.customerId != null
-                    ? service.getCustomer(appt.customerId!)?.fullName ??
-                        AppLocalizations.of(context)!.unknownUser
-                    : appt.guestName ??
-                        AppLocalizations.of(context)!.unknownUser;
-                return ListTile(
-                  leading: CircleAvatar(
-                    backgroundColor: serviceTypeColor(appt.service),
-                    child: ImageIcon(
-                      AssetImage(serviceTypeIcon(appt.service)),
-                      color: Theme.of(context).colorScheme.onPrimary,
-                    ),
-                  ),
-                    title: Text(
-                      '${serviceTypeLabel(context, appt.service)} - $providerName${appt.price != null ? ' (\$${appt.price!.toStringAsFixed(2)})' : ''}',
-                    ),
-                    subtitle: Text(
-                      (StringBuffer()
-                            ..write(DateFormat.yMMMd(locale)
-                                .format(appt.dateTime.toLocal()))
-                            ..write(' ')
-                            ..write(DateFormat.jm(locale)
-                                .format(appt.dateTime.toLocal()))
-                            ..write(' - ')
-                            ..write(DateFormat.jm(locale).format(
-                                appt.dateTime.toLocal().add(appt.duration)))
-                            ..write('\n')
-                            ..write(customerName)
-                            ..write(appt.location != null
-                                ? ' @ ${appt.location}'
-                                : ''))
-                          .toString(),
-                    ),
-                  isThreeLine: true,
+                final appt = appointments[index];
+                return AppointmentTile(
+                  appointment: appt,
+                  showDate: true,
                   onTap: () {
                     Navigator.push(
                       context,
@@ -126,21 +89,18 @@ class AppointmentsPage extends StatelessWidget {
                         context: context,
                         builder: (context) {
                           return AlertDialog(
-                            title: Text(
-                                AppLocalizations.of(context)!
-                                    .appointmentsTitle),
+                            title:
+                                Text(AppLocalizations.of(context)!.appointmentsTitle),
                             content: Text(AppLocalizations.of(context)!
                                 .deleteAppointmentTooltip),
                             actions: [
                               TextButton(
-                                onPressed: () =>
-                                    Navigator.pop(context, false),
-                                child: Text(AppLocalizations.of(context)!
-                                    .cancelButton),
+                                onPressed: () => Navigator.pop(context, false),
+                                child: Text(
+                                    AppLocalizations.of(context)!.cancelButton),
                               ),
                               TextButton(
-                                onPressed: () =>
-                                    Navigator.pop(context, true),
+                                onPressed: () => Navigator.pop(context, true),
                                 child: Text(AppLocalizations.of(context)!
                                     .deleteAppointmentTooltip),
                               ),

--- a/lib/screens/calendar_page.dart
+++ b/lib/screens/calendar_page.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models/appointment.dart';
 import '../services/appointment_service.dart';
-import '../utils/service_type_utils.dart';
 import '../widgets/app_scaffold.dart';
+import '../widgets/appointment_tile.dart';
 
 /// Displays appointments on a calendar and lists those for the
 /// currently selected day.
@@ -33,7 +32,6 @@ class _CalendarPageState extends State<CalendarPage> {
   @override
   Widget build(BuildContext context) {
     final service = context.watch<AppointmentService>();
-    final locale = Localizations.localeOf(context).toString();
 
     final selectedAppointments = service.appointments
         .where((a) => isSameDay(a.dateTime, _selectedDay))
@@ -69,41 +67,9 @@ class _CalendarPageState extends State<CalendarPage> {
                     itemCount: selectedAppointments.length,
                     itemBuilder: (context, index) {
                       final appt = selectedAppointments[index];
-                      final providerName = appt.providerId != null
-                          ? service.getUser(appt.providerId!)?.name ??
-                                AppLocalizations.of(context)!.unknownUser
-                          : AppLocalizations.of(context)!.unknownUser;
-                      final customerName = appt.customerId != null
-                          ? service.getCustomer(appt.customerId!)?.fullName ??
-                              AppLocalizations.of(context)!.unknownUser
-                          : appt.guestName ??
-                              AppLocalizations.of(context)!.unknownUser;
-                      return ListTile(
-                        leading: CircleAvatar(
-                          backgroundColor: serviceTypeColor(appt.service),
-                          child: ImageIcon(
-                            AssetImage(serviceTypeIcon(appt.service)),
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                        ),
-                          title: Text(
-                            '${serviceTypeLabel(context, appt.service)} - $providerName${appt.price != null ? ' (\$${appt.price!.toStringAsFixed(2)})' : ''}',
-                          ),
-                          subtitle: Text(
-                            (StringBuffer()
-                                  ..write(DateFormat.jm(locale)
-                                      .format(appt.dateTime.toLocal()))
-                                  ..write(' - ')
-                                  ..write(DateFormat.jm(locale).format(
-                                      appt.dateTime.toLocal().add(appt.duration)))
-                                  ..write('\n')
-                                  ..write(customerName)
-                                  ..write(appt.location != null
-                                      ? ' @ ${appt.location}'
-                                      : ''))
-                                .toString(),
-                          ),
-                        isThreeLine: true,
+                      return AppointmentTile(
+                        appointment: appt,
+                        showDate: false,
                       );
                     },
                   ),

--- a/lib/widgets/appointment_tile.dart
+++ b/lib/widgets/appointment_tile.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/appointment.dart';
+import '../services/appointment_service.dart';
+import '../utils/service_type_utils.dart';
+
+/// Displays information about an [Appointment] in a [ListTile].
+///
+/// The tile shows the service type, provider, optional price, time range,
+/// customer name and optional location. Consumers may supply [onTap] and
+/// [trailing] widgets to customize interactions.
+class AppointmentTile extends StatelessWidget {
+  final Appointment appointment;
+  final VoidCallback? onTap;
+  final Widget? trailing;
+
+  /// Whether the date portion should be included in the subtitle.
+  ///
+  /// [AppointmentsPage] shows the date while [CalendarPage] omits it because
+  /// the date is already selected in the calendar. Defaults to `true`.
+  final bool showDate;
+
+  const AppointmentTile({
+    super.key,
+    required this.appointment,
+    this.onTap,
+    this.trailing,
+    this.showDate = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<AppointmentService>();
+    final locale = Localizations.localeOf(context).toString();
+
+    final providerName = appointment.providerId != null
+        ? service.getUser(appointment.providerId!)?.name ??
+            AppLocalizations.of(context)!.unknownUser
+        : AppLocalizations.of(context)!.unknownUser;
+    final customerName = appointment.customerId != null
+        ? service.getCustomer(appointment.customerId!)?.fullName ??
+            AppLocalizations.of(context)!.unknownUser
+        : appointment.guestName ??
+            AppLocalizations.of(context)!.unknownUser;
+
+    final buffer = StringBuffer();
+    if (showDate) {
+      buffer
+          .write(DateFormat.yMMMd(locale).format(appointment.dateTime.toLocal()));
+      buffer.write(' ');
+    }
+    buffer.write(DateFormat.jm(locale).format(appointment.dateTime.toLocal()));
+    buffer.write(' - ');
+    buffer.write(DateFormat.jm(locale)
+        .format(appointment.dateTime.toLocal().add(appointment.duration)));
+    buffer.write('\n');
+    buffer.write(customerName);
+    if (appointment.location != null) {
+      buffer.write(' @ ${appointment.location}');
+    }
+
+    final priceStr = appointment.price != null
+        ? ' (\$${appointment.price!.toStringAsFixed(2)})'
+        : '';
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: serviceTypeColor(appointment.service),
+        child: ImageIcon(
+          AssetImage(serviceTypeIcon(appointment.service)),
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
+      ),
+      title: Text(
+        '${serviceTypeLabel(context, appointment.service)} - $providerName$priceStr',
+      ),
+      subtitle: Text(buffer.toString()),
+      isThreeLine: true,
+      onTap: onTap,
+      trailing: trailing,
+    );
+  }
+}
+

--- a/test/widgets/appointment_tile_test.dart
+++ b/test/widgets/appointment_tile_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/models/appointment.dart';
+import 'package:vogue_vault/models/customer.dart';
+import 'package:vogue_vault/models/service_type.dart';
+import 'package:vogue_vault/models/user_profile.dart';
+import 'package:vogue_vault/services/appointment_service.dart';
+import 'package:vogue_vault/widgets/appointment_tile.dart';
+
+class _FakeAppointmentService extends AppointmentService {
+  final Map<String, UserProfile> _users;
+  final Map<String, Customer> _customers;
+
+  _FakeAppointmentService(this._users, this._customers);
+
+  @override
+  UserProfile? getUser(String id) => _users[id];
+
+  @override
+  Customer? getCustomer(String id) => _customers[id];
+}
+
+void main() {
+  testWidgets('appointment tile shows provider, customer and price', (tester) async {
+    final appt = Appointment(
+      id: '1',
+      service: ServiceType.barber,
+      dateTime: DateTime(2023, 1, 1, 10),
+      duration: const Duration(hours: 1),
+      providerId: 'p1',
+      customerId: 'c1',
+      price: 50,
+      location: 'Salon',
+    );
+    final service = _FakeAppointmentService({
+      'p1': UserProfile(id: 'p1', firstName: 'Alex', lastName: 'Smith'),
+    }, {
+      'c1': Customer(id: 'c1', firstName: 'Jane', lastName: 'Doe'),
+    });
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppointmentService>.value(
+        value: service,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: AppointmentTile(appointment: appt)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Barber - Alex Smith (\$50.00)'), findsOneWidget);
+    expect(find.textContaining('Jane Doe @ Salon'), findsOneWidget);
+  });
+
+  testWidgets('appointment tile can hide date', (tester) async {
+    final appt = Appointment(
+      id: '1',
+      service: ServiceType.nails,
+      dateTime: DateTime(2023, 1, 1, 10),
+      duration: const Duration(hours: 1),
+    );
+
+    final service = _FakeAppointmentService({}, {});
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppointmentService>.value(
+        value: service,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: AppointmentTile(appointment: appt, showDate: false),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final listTile = tester.widget<ListTile>(find.byType(ListTile));
+    final subtitle = listTile.subtitle as Text;
+    expect(subtitle.data!.contains('2023'), isFalse);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add reusable `AppointmentTile` widget for consistent appointment rendering
- replace inline `ListTile` logic in appointments and calendar pages
- test appointment tile formatting

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5130d7c8c832b956b9671ae19a3ee