### PR TITLE
Add form validation for service offerings

### DIFF
--- a/lib/screens/manage_services_page.dart
+++ b/lib/screens/manage_services_page.dart
@@ -18,6 +18,8 @@ class ManageServicesPage extends StatefulWidget {
 }
 
 class _ManageServicesPageState extends State<ManageServicesPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _editorKey = GlobalKey<ServiceOfferingEditorState>();
   late List<ServiceOffering> _offerings;
   late String _userId;
 
@@ -31,6 +33,7 @@ class _ManageServicesPageState extends State<ManageServicesPage> {
   }
 
   Future<void> _save() async {
+    if (!(_editorKey.currentState?.validate() ?? false)) return;
     final service = context.read<AppointmentService>();
     final user = service.getUser(_userId);
     if (user != null) {
@@ -48,9 +51,13 @@ class _ManageServicesPageState extends State<ManageServicesPage> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            ServiceOfferingEditor(
-              offerings: _offerings,
-              onChanged: (list) => setState(() => _offerings = list),
+            Form(
+              key: _formKey,
+              child: ServiceOfferingEditor(
+                key: _editorKey,
+                offerings: _offerings,
+                onChanged: (list) => setState(() => _offerings = list),
+              ),
             ),
             const SizedBox(height: 24),
             SizedBox(

--- a/lib/widgets/service_offering_editor.dart
+++ b/lib/widgets/service_offering_editor.dart
@@ -23,10 +23,10 @@ class ServiceOfferingEditor extends StatefulWidget {
   });
 
   @override
-  State<ServiceOfferingEditor> createState() => _ServiceOfferingEditorState();
+  ServiceOfferingEditorState createState() => ServiceOfferingEditorState();
 }
 
-class _ServiceOfferingEditorState extends State<ServiceOfferingEditor> {
+class ServiceOfferingEditorState extends State<ServiceOfferingEditor> {
   late List<ServiceOffering> _offerings;
 
   @override
@@ -44,6 +44,9 @@ class _ServiceOfferingEditorState extends State<ServiceOfferingEditor> {
   }
 
   void _notify() => widget.onChanged(List.unmodifiable(_offerings));
+
+  /// Validates all fields within the surrounding [Form].
+  bool validate() => Form.of(context)?.validate() ?? false;
 
   @override
   Widget build(BuildContext context) {

--- a/test/screens/manage_services_page_test.dart
+++ b/test/screens/manage_services_page_test.dart
@@ -97,4 +97,34 @@ void main() {
     expect(appt.updated, isNotNull);
     expect(appt.updated!.offerings, isEmpty);
   });
+
+  testWidgets('invalid price prevents saving', (tester) async {
+    final auth = _FakeAuthService();
+    final appt = _FakeAppointmentService();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthService>.value(value: auth),
+          ChangeNotifierProvider<AppointmentService>.value(value: appt),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ManageServicesPage(userId: 'test@example.com'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Add'));
+    await tester.pump();
+
+    final priceField = find.widgetWithText(TextFormField, 'Price');
+    await tester.enterText(priceField, '-5');
+
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(appt.updated, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- Wrap service offering editor in a form to validate inputs
- Expose validation method for service offering editor
- Prevent saving service offerings when invalid values are entered

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b515c029f0832b98c977ba05f0ad33