### PR TITLE
Centralize auth styling in theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,13 +14,18 @@ import 'services/auth_service.dart';
 import 'services/notification_service.dart';
 
 InputDecorationTheme _buildInputDecorationTheme(ColorScheme scheme) {
+  final border = OutlineInputBorder(
+    borderRadius: BorderRadius.circular(30),
+    borderSide: BorderSide.none,
+  );
   return InputDecorationTheme(
-    focusedBorder: OutlineInputBorder(
-      borderSide: BorderSide(color: scheme.onSurface),
-    ),
-    enabledBorder: OutlineInputBorder(
-      borderSide: BorderSide(color: scheme.onSurface),
-    ),
+    filled: true,
+    fillColor: scheme.surface,
+    prefixIconColor: scheme.onSurface,
+    suffixIconColor: scheme.onSurface,
+    border: border,
+    enabledBorder: border,
+    focusedBorder: border,
     labelStyle: TextStyle(color: scheme.onSurface),
     floatingLabelStyle: TextStyle(color: scheme.onSurface),
     hintStyle: TextStyle(color: scheme.onSurface.withOpacity(0.6)),
@@ -31,6 +36,11 @@ const TextTheme _textTheme = TextTheme(
   headlineLarge: TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.bold,
+  ),
+  headlineMedium: TextStyle(
+    fontFamily: 'LibertinusSans',
+    fontSize: 32,
+    fontWeight: FontWeight.w400,
   ),
   bodyMedium: TextStyle(fontSize: 16),
 );

--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -87,11 +87,7 @@ class _AuthPageState extends State<AuthPage> {
                   Text(
                     AppLocalizations.of(context)!.appTitle,
                     textAlign: TextAlign.center,
-                    style: theme.textTheme.headlineMedium?.copyWith(
-                      color: colors.onSurface,
-                      fontFamily: 'LibertinusSans',
-                      fontWeight: FontWeight.w400,
-                    ),
+                    style: theme.textTheme.headlineMedium,
                   ),
                   const SizedBox(height: 16),
                   Semantics(
@@ -105,17 +101,9 @@ class _AuthPageState extends State<AuthPage> {
                   const SizedBox(height: 32),
                   TextFormField(
                     controller: _emailController,
-                    style: TextStyle(color: colors.onSurface),
-                    cursorColor: colors.onSurface,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.emailLabel,
-                      prefixIcon: Icon(Icons.email, color: colors.onSurface),
-                      filled: true,
-                      fillColor: colors.surface,
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(30),
-                        borderSide: BorderSide.none,
-                      ),
+                      prefixIcon: const Icon(Icons.email),
                     ),
                     validator: (value) {
                       if (value == null || value.isEmpty) {
@@ -131,27 +119,18 @@ class _AuthPageState extends State<AuthPage> {
                   const SizedBox(height: 16),
                   TextFormField(
                     controller: _passwordController,
-                    style: TextStyle(color: colors.onSurface),
-                    cursorColor: colors.onSurface,
                     obscureText: !_showPassword,
                     decoration: InputDecoration(
                       hintText: AppLocalizations.of(context)!.passwordLabel,
-                      prefixIcon: Icon(Icons.lock, color: colors.onSurface),
+                      prefixIcon: const Icon(Icons.lock),
                       suffixIcon: IconButton(
                         icon: Icon(
                           _showPassword
                               ? Icons.visibility_off
                               : Icons.visibility,
-                          color: colors.onSurface,
                         ),
                         onPressed: () =>
                             setState(() => _showPassword = !_showPassword),
-                      ),
-                      filled: true,
-                      fillColor: colors.surface,
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(30),
-                        borderSide: BorderSide.none,
                       ),
                     ),
                     validator: (value) {
@@ -173,14 +152,6 @@ class _AuthPageState extends State<AuthPage> {
                   const SizedBox(height: 24),
                   ElevatedButton(
                     onPressed: _submit,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: colors.primary,
-                      foregroundColor: colors.onPrimary,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(30),
-                      ),
-                    ),
                     child: Text(AppLocalizations.of(context)!.loginButton),
                   ),
                   const SizedBox(height: 12),
@@ -195,17 +166,6 @@ class _AuthPageState extends State<AuthPage> {
                         ),
                       );
                     },
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor:
-                          Theme.of(context).colorScheme.primary,
-                      side: BorderSide(
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(30),
-                      ),
-                    ),
                     child: Text(AppLocalizations.of(context)!.createAccount),
                   ),
                 ],


### PR DESCRIPTION
## Summary
- Define LibertinusSans as the app's headline font in ThemeData
- Apply rounded, filled input decoration themewide
- Clean up AuthPage to rely on theme styles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b517b5abd4832b9f7d0473e28bece1