### PR TITLE
Use store icon for business navigation

### DIFF
--- a/lib/screens/appointments_page.dart
+++ b/lib/screens/appointments_page.dart
@@ -32,7 +32,7 @@ class AppointmentsPage extends StatelessWidget {
           },
         ),
         IconButton(
-          icon: const Icon(Icons.person),
+          icon: const Icon(Icons.store),
           tooltip: AppLocalizations.of(context)!.myBusinessTooltip,
           onPressed: () {
             Navigator.push(


### PR DESCRIPTION
## Summary
- replace generic person icon with store icon when navigating to business page

## Testing
- `dart format lib/screens/appointments_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c1e82be0832b88c6deca89133dc2