### PR TITLE
Add SettingsService for theme mode persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'screens/auth_page.dart';
 import 'services/appointment_service.dart';
 import 'services/auth_service.dart';
 import 'services/notification_service.dart';
+import 'services/settings_service.dart';
 
 InputDecorationTheme _buildInputDecorationTheme(ColorScheme scheme) {
   final border = OutlineInputBorder(
@@ -57,21 +58,26 @@ Future<void> main() async {
   await appointmentService.init();
   final authService = AuthService();
   await authService.init();
+  final settingsService = SettingsService();
+  await settingsService.init();
 
   runApp(
-    MultiProvider(
-      providers: [
-        ChangeNotifierProvider<AppointmentService>.value(
-          value: appointmentService,
-        ),
-        ChangeNotifierProvider<AuthService>.value(
-          value: authService,
-        ),
-        Provider<NotificationService>.value(
-          value: notificationService,
-        ),
-      ],
-      child: const MyApp(),
+    ChangeNotifierProvider<SettingsService>.value(
+      value: settingsService,
+      child: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AppointmentService>.value(
+            value: appointmentService,
+          ),
+          ChangeNotifierProvider<AuthService>.value(
+            value: authService,
+          ),
+          Provider<NotificationService>.value(
+            value: notificationService,
+          ),
+        ],
+        child: const MyApp(),
+      ),
     ),
   );
 }
@@ -81,6 +87,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final settingsService = context.watch<SettingsService>();
     final lightScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primary,
     ).copyWith(
@@ -128,6 +135,7 @@ class MyApp extends StatelessWidget {
       supportedLocales: AppLocalizations.supportedLocales,
       // Start the app with authentication.
       home: const AuthPage(),
+      themeMode: settingsService.themeMode,
     );
   }
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class SettingsService extends ChangeNotifier {
+  static const _boxName = 'settings';
+  static const _themeModeKey = 'themeMode';
+
+  late Box _box;
+  bool _initialized = false;
+  ThemeMode _themeMode = ThemeMode.system;
+
+  bool get isInitialized => _initialized;
+
+  ThemeMode get themeMode {
+    _ensureInitialized();
+    return _themeMode;
+  }
+
+  Future<void> init() async {
+    _box = await Hive.openBox(_boxName);
+    final stored = _box.get(_themeModeKey);
+    if (stored is int && stored >= 0 && stored < ThemeMode.values.length) {
+      _themeMode = ThemeMode.values[stored];
+    }
+    _initialized = true;
+  }
+
+  void _ensureInitialized() {
+    if (!_initialized) {
+      throw StateError('SettingsService has not been initialized.');
+    }
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    _ensureInitialized();
+    _themeMode = mode;
+    await _box.put(_themeModeKey, mode.index);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    if (_initialized) {
+      _box.close();
+    }
+    super.dispose();
+  }
+}

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:vogue_vault/services/settings_service.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('setThemeMode persists value', () async {
+    final service = SettingsService();
+    await service.init();
+
+    await service.setThemeMode(ThemeMode.dark);
+    expect(service.themeMode, ThemeMode.dark);
+
+    final reloaded = SettingsService();
+    await reloaded.init();
+    expect(reloaded.themeMode, ThemeMode.dark);
+  });
+
+  test('setThemeMode notifies listeners', () async {
+    final service = SettingsService();
+    await service.init();
+
+    var notified = false;
+    service.addListener(() {
+      notified = true;
+    });
+
+    await service.setThemeMode(ThemeMode.light);
+    expect(notified, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add SettingsService using Hive to persist selected ThemeMode
- wire SettingsService into main app and MaterialApp themeMode
- test SettingsService persistence and listener notifications

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c6e9d6c0832b9172a509659cb104