### PR TITLE
Add settings page with theme and language options

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -80,6 +80,7 @@
   "addressLabel": "Address",
   "requiredField": "Required",
   "notificationSettingsTitle": "Notification Settings",
+  "settingsTitle": "Settings",
   "minutesBefore": "{minutes} minutes before",
   "@minutesBefore": {
     "description": "Label for reminder offset",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -80,6 +80,7 @@
   "addressLabel": "Dirección",
   "requiredField": "Requerido",
   "notificationSettingsTitle": "Configuración de notificaciones",
+  "settingsTitle": "Configuración",
   "minutesBefore": "{minutes} minutos antes",
   "@minutesBefore": {
     "description": "Etiqueta para el tiempo de recordatorio",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -578,6 +578,12 @@ abstract class AppLocalizations {
   /// **'Notification Settings'**
   String get notificationSettingsTitle;
 
+  /// No description provided for @settingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settingsTitle;
+
   /// Label for reminder offset
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -253,6 +253,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notificationSettingsTitle => 'Notification Settings';
 
   @override
+  String get settingsTitle => 'Settings';
+
+  @override
   String minutesBefore(int minutes) {
     return '$minutes minutes before';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -253,6 +253,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get notificationSettingsTitle => 'Configuración de notificaciones';
 
   @override
+  String get settingsTitle => 'Configuración';
+
+  @override
   String minutesBefore(int minutes) {
     return '$minutes minutos antes';
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,6 +133,7 @@ class MyApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
+      locale: settingsService.locale,
       // Start the app with authentication.
       home: const AuthPage(),
       themeMode: settingsService.themeMode,

--- a/lib/screens/my_business_page.dart
+++ b/lib/screens/my_business_page.dart
@@ -4,6 +4,7 @@ import 'package:vogue_vault/l10n/app_localizations.dart';
 import 'customers_page.dart';
 import 'addresses_page.dart';
 import 'notification_settings_page.dart';
+import 'settings_page.dart';
 import '../widgets/app_scaffold.dart';
 
 class MyBusinessPage extends StatelessWidget {
@@ -46,6 +47,16 @@ class MyBusinessPage extends StatelessWidget {
                 MaterialPageRoute(
                   builder: (_) => const NotificationSettingsPage(),
                 ),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.settings),
+            title: Text(AppLocalizations.of(context)!.settingsTitle),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsPage()),
               );
             },
           ),

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
+
+import '../services/settings_service.dart';
+import '../widgets/app_scaffold.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final service = context.watch<SettingsService>();
+
+    return AppScaffold(
+      title: l10n.settingsTitle,
+      body: ListView(
+        children: [
+          RadioListTile<ThemeMode>(
+            title: const Text('System'),
+            value: ThemeMode.system,
+            groupValue: service.themeMode,
+            onChanged: (mode) {
+              if (mode != null) {
+                service.setThemeMode(mode);
+              }
+            },
+          ),
+          RadioListTile<ThemeMode>(
+            title: const Text('Light'),
+            value: ThemeMode.light,
+            groupValue: service.themeMode,
+            onChanged: (mode) {
+              if (mode != null) {
+                service.setThemeMode(mode);
+              }
+            },
+          ),
+          RadioListTile<ThemeMode>(
+            title: const Text('Dark'),
+            value: ThemeMode.dark,
+            groupValue: service.themeMode,
+            onChanged: (mode) {
+              if (mode != null) {
+                service.setThemeMode(mode);
+              }
+            },
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('Language'),
+            trailing: DropdownButton<Locale>(
+              value: service.locale,
+              onChanged: (locale) {
+                if (locale != null) {
+                  service.setLocale(locale);
+                }
+              },
+              items: const [
+                DropdownMenuItem(
+                  value: Locale('en'),
+                  child: Text('English'),
+                ),
+                DropdownMenuItem(
+                  value: Locale('es'),
+                  child: Text('Español'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -4,10 +4,12 @@ import 'package:hive_flutter/hive_flutter.dart';
 class SettingsService extends ChangeNotifier {
   static const _boxName = 'settings';
   static const _themeModeKey = 'themeMode';
+  static const _localeKey = 'locale';
 
   late Box _box;
   bool _initialized = false;
   ThemeMode _themeMode = ThemeMode.system;
+  Locale _locale = const Locale('en');
 
   bool get isInitialized => _initialized;
 
@@ -16,11 +18,22 @@ class SettingsService extends ChangeNotifier {
     return _themeMode;
   }
 
+  Locale get locale {
+    _ensureInitialized();
+    return _locale;
+  }
+
   Future<void> init() async {
     _box = await Hive.openBox(_boxName);
-    final stored = _box.get(_themeModeKey);
-    if (stored is int && stored >= 0 && stored < ThemeMode.values.length) {
-      _themeMode = ThemeMode.values[stored];
+    final storedTheme = _box.get(_themeModeKey);
+    if (storedTheme is int &&
+        storedTheme >= 0 &&
+        storedTheme < ThemeMode.values.length) {
+      _themeMode = ThemeMode.values[storedTheme];
+    }
+    final storedLocale = _box.get(_localeKey);
+    if (storedLocale is String && storedLocale.isNotEmpty) {
+      _locale = Locale(storedLocale);
     }
     _initialized = true;
   }
@@ -35,6 +48,13 @@ class SettingsService extends ChangeNotifier {
     _ensureInitialized();
     _themeMode = mode;
     await _box.put(_themeModeKey, mode.index);
+    notifyListeners();
+  }
+
+  Future<void> setLocale(Locale locale) async {
+    _ensureInitialized();
+    _locale = locale;
+    await _box.put(_localeKey, locale.languageCode);
     notifyListeners();
   }
 

--- a/test/screens/settings_page_test.dart
+++ b/test/screens/settings_page_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:vogue_vault/l10n/app_localizations.dart';
+import 'package:vogue_vault/screens/settings_page.dart';
+import 'package:vogue_vault/services/settings_service.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  testWidgets('toggling theme updates service', (tester) async {
+    final service = SettingsService();
+    await service.init();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SettingsService>.value(
+        value: service,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SettingsPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(RadioListTile<ThemeMode>, 'Dark'));
+    await tester.pumpAndSettle();
+
+    expect(service.themeMode, ThemeMode.dark);
+  });
+
+  testWidgets('changing language updates service', (tester) async {
+    final service = SettingsService();
+    await service.init();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SettingsService>.value(
+        value: service,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SettingsPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButton<Locale>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Español').last);
+    await tester.pumpAndSettle();
+
+    expect(service.locale.languageCode, 'es');
+  });
+}


### PR DESCRIPTION
## Summary
- add SettingsPage with theme and language preferences
- persist theme and locale in SettingsService
- link SettingsPage from MyBusinessPage and wire locale into MaterialApp
- test settings page for toggling theme and language

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c9bde80c832b99d9ca122dd9ae42