### PR TITLE
Add localized settings strings and tests

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -81,6 +81,11 @@
   "requiredField": "Required",
   "notificationSettingsTitle": "Notification Settings",
   "settingsTitle": "Settings",
+  "themeLabel": "Theme",
+  "themeSystem": "System",
+  "themeLight": "Light",
+  "themeDark": "Dark",
+  "languageLabel": "Language",
   "minutesBefore": "{minutes} minutes before",
   "@minutesBefore": {
     "description": "Label for reminder offset",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -81,6 +81,11 @@
   "requiredField": "Requerido",
   "notificationSettingsTitle": "Configuración de notificaciones",
   "settingsTitle": "Configuración",
+  "themeLabel": "Tema",
+  "themeSystem": "Sistema",
+  "themeLight": "Claro",
+  "themeDark": "Oscuro",
+  "languageLabel": "Idioma",
   "minutesBefore": "{minutes} minutos antes",
   "@minutesBefore": {
     "description": "Etiqueta para el tiempo de recordatorio",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -62,8 +62,7 @@ import 'app_localizations_es.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -71,8 +70,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -84,18 +82,17 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es'),
+    Locale('es')
   ];
 
   /// No description provided for @appTitle.
@@ -584,6 +581,36 @@ abstract class AppLocalizations {
   /// **'Settings'**
   String get settingsTitle;
 
+  /// No description provided for @themeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get themeLabel;
+
+  /// No description provided for @themeSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get themeSystem;
+
+  /// No description provided for @themeLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeLight;
+
+  /// No description provided for @themeDark.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeDark;
+
+  /// No description provided for @languageLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get languageLabel;
+
   /// Label for reminder offset
   ///
   /// In en, this message translates to:
@@ -591,8 +618,7 @@ abstract class AppLocalizations {
   String minutesBefore(int minutes);
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -601,26 +627,25 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['en', 'es'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en', 'es'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
+    'that was used.'
   );
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -60,8 +60,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileTitle => 'Profile';
 
   @override
-  String get imageSelectionUnsupported =>
-      'Image selection not supported on this platform';
+  String get imageSelectionUnsupported => 'Image selection not supported on this platform';
 
   @override
   String get nameLabel => 'Name';
@@ -205,8 +204,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get serviceTypeTattoo => 'Tattoo Artist';
 
   @override
-  String get appointmentConflict =>
-      'Appointment conflicts with existing booking';
+  String get appointmentConflict => 'Appointment conflicts with existing booking';
 
   @override
   String get deleteUserTooltip => 'Delete user';
@@ -221,15 +219,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAppointmentTitle => 'Delete Appointment';
 
   @override
-  String get deleteAppointmentConfirmation =>
-      'Are you sure you want to delete this appointment?';
+  String get deleteAppointmentConfirmation => 'Are you sure you want to delete this appointment?';
 
   @override
   String get deleteUserTitle => 'Delete User';
 
   @override
-  String get deleteUserConfirmation =>
-      'Are you sure you want to delete this user?';
+  String get deleteUserConfirmation => 'Are you sure you want to delete this user?';
 
   @override
   String get addressesTitle => 'Addresses';
@@ -254,6 +250,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsTitle => 'Settings';
+
+  @override
+  String get themeLabel => 'Theme';
+
+  @override
+  String get themeSystem => 'System';
+
+  @override
+  String get themeLight => 'Light';
+
+  @override
+  String get themeDark => 'Dark';
+
+  @override
+  String get languageLabel => 'Language';
 
   @override
   String minutesBefore(int minutes) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -60,8 +60,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileTitle => 'Perfil';
 
   @override
-  String get imageSelectionUnsupported =>
-      'La selección de imágenes no es compatible con esta plataforma';
+  String get imageSelectionUnsupported => 'La selección de imágenes no es compatible con esta plataforma';
 
   @override
   String get nameLabel => 'Nombre';
@@ -205,8 +204,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get serviceTypeTattoo => 'Tatuador';
 
   @override
-  String get appointmentConflict =>
-      'La cita entra en conflicto con una reserva existente';
+  String get appointmentConflict => 'La cita entra en conflicto con una reserva existente';
 
   @override
   String get deleteUserTooltip => 'Eliminar usuario';
@@ -221,15 +219,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAppointmentTitle => 'Eliminar cita';
 
   @override
-  String get deleteAppointmentConfirmation =>
-      '¿Está seguro de que desea eliminar esta cita?';
+  String get deleteAppointmentConfirmation => '¿Está seguro de que desea eliminar esta cita?';
 
   @override
   String get deleteUserTitle => 'Eliminar usuario';
 
   @override
-  String get deleteUserConfirmation =>
-      '¿Está seguro de que desea eliminar este usuario?';
+  String get deleteUserConfirmation => '¿Está seguro de que desea eliminar este usuario?';
 
   @override
   String get addressesTitle => 'Direcciones';
@@ -254,6 +250,21 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsTitle => 'Configuración';
+
+  @override
+  String get themeLabel => 'Tema';
+
+  @override
+  String get themeSystem => 'Sistema';
+
+  @override
+  String get themeLight => 'Claro';
+
+  @override
+  String get themeDark => 'Oscuro';
+
+  @override
+  String get languageLabel => 'Idioma';
 
   @override
   String minutesBefore(int minutes) {

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -17,8 +17,11 @@ class SettingsPage extends StatelessWidget {
       title: l10n.settingsTitle,
       body: ListView(
         children: [
+          ListTile(
+            title: Text(l10n.themeLabel),
+          ),
           RadioListTile<ThemeMode>(
-            title: const Text('System'),
+            title: Text(l10n.themeSystem),
             value: ThemeMode.system,
             groupValue: service.themeMode,
             onChanged: (mode) {
@@ -28,7 +31,7 @@ class SettingsPage extends StatelessWidget {
             },
           ),
           RadioListTile<ThemeMode>(
-            title: const Text('Light'),
+            title: Text(l10n.themeLight),
             value: ThemeMode.light,
             groupValue: service.themeMode,
             onChanged: (mode) {
@@ -38,7 +41,7 @@ class SettingsPage extends StatelessWidget {
             },
           ),
           RadioListTile<ThemeMode>(
-            title: const Text('Dark'),
+            title: Text(l10n.themeDark),
             value: ThemeMode.dark,
             groupValue: service.themeMode,
             onChanged: (mode) {
@@ -49,7 +52,7 @@ class SettingsPage extends StatelessWidget {
           ),
           const Divider(),
           ListTile(
-            title: const Text('Language'),
+            title: Text(l10n.languageLabel),
             trailing: DropdownButton<Locale>(
               value: service.locale,
               onChanged: (locale) {

--- a/test/l10n/localization_test.dart
+++ b/test/l10n/localization_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vogue_vault/l10n/app_localizations.dart';
+
+void main() {
+  test('new localization keys have values for all locales', () async {
+    for (final locale in AppLocalizations.supportedLocales) {
+      final l10n = await AppLocalizations.delegate.load(locale);
+      expect(l10n.settingsTitle, isNotEmpty,
+          reason: 'settingsTitle missing for ${locale.languageCode}');
+      expect(l10n.themeLabel, isNotEmpty,
+          reason: 'themeLabel missing for ${locale.languageCode}');
+      expect(l10n.themeSystem, isNotEmpty,
+          reason: 'themeSystem missing for ${locale.languageCode}');
+      expect(l10n.themeLight, isNotEmpty,
+          reason: 'themeLight missing for ${locale.languageCode}');
+      expect(l10n.themeDark, isNotEmpty,
+          reason: 'themeDark missing for ${locale.languageCode}');
+      expect(l10n.languageLabel, isNotEmpty,
+          reason: 'languageLabel missing for ${locale.languageCode}');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- localize theme and language labels in ARB files and regenerate l10n code
- replace SettingsPage hardcoded labels with AppLocalizations lookups
- add tests verifying new localization keys resolve for supported locales

## Testing
- `flutter gen-l10n`
- `flutter test` *(fails: The argument type 'Null' can't be assigned to the parameter type 'Appointment'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cf72457c832bbf13b665d80420cb