### PR TITLE
feat: persist user-selected locale

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,7 +133,7 @@ class MyApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-      locale: settingsService.locale,
+      locale: settingsService.locale ?? null,
       // Start the app with authentication.
       home: const AuthPage(),
       themeMode: settingsService.themeMode,

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -53,19 +53,19 @@ class SettingsPage extends StatelessWidget {
           const Divider(),
           ListTile(
             title: Text(l10n.languageLabel),
-            trailing: DropdownButton<Locale>(
+            trailing: DropdownButton<Locale?>(
               value: service.locale,
-              onChanged: (locale) {
-                if (locale != null) {
-                  service.setLocale(locale);
-                }
-              },
-              items: const [
-                DropdownMenuItem(
+              onChanged: service.setLocale,
+              items: [
+                DropdownMenuItem<Locale?> (
+                  value: null,
+                  child: Text(l10n.themeSystem),
+                ),
+                const DropdownMenuItem(
                   value: Locale('en'),
                   child: Text('English'),
                 ),
-                DropdownMenuItem(
+                const DropdownMenuItem(
                   value: Locale('es'),
                   child: Text('Español'),
                 ),

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -9,7 +9,7 @@ class SettingsService extends ChangeNotifier {
   late Box _box;
   bool _initialized = false;
   ThemeMode _themeMode = ThemeMode.system;
-  Locale _locale = const Locale('en');
+  Locale? _locale;
 
   bool get isInitialized => _initialized;
 
@@ -18,7 +18,7 @@ class SettingsService extends ChangeNotifier {
     return _themeMode;
   }
 
-  Locale get locale {
+  Locale? get locale {
     _ensureInitialized();
     return _locale;
   }
@@ -51,10 +51,14 @@ class SettingsService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> setLocale(Locale locale) async {
+  Future<void> setLocale(Locale? locale) async {
     _ensureInitialized();
     _locale = locale;
-    await _box.put(_localeKey, locale.languageCode);
+    if (locale != null) {
+      await _box.put(_localeKey, locale.languageCode);
+    } else {
+      await _box.delete(_localeKey);
+    }
     notifyListeners();
   }
 

--- a/test/main_locale_test.dart
+++ b/test/main_locale_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'package:vogue_vault/services/settings_service.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+
+  @override
+  Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+    await Hive.initFlutter();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  testWidgets('MaterialApp updates when locale changes', (tester) async {
+    final service = SettingsService();
+    await service.init();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SettingsService>.value(
+        value: service,
+        child: Consumer<SettingsService>(
+          builder: (_, settings, __) {
+            return MaterialApp(
+              localizationsDelegates: const [
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: const [Locale('en'), Locale('es')],
+              locale: settings.locale ?? null,
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(
+      tester.widget<MaterialApp>(find.byType(MaterialApp)).locale,
+      isNull,
+    );
+
+    await service.setLocale(const Locale('es'));
+    await tester.pump();
+
+    expect(
+      tester.widget<MaterialApp>(find.byType(MaterialApp)).locale,
+      const Locale('es'),
+    );
+  });
+}

--- a/test/screens/settings_page_test.dart
+++ b/test/screens/settings_page_test.dart
@@ -73,11 +73,11 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButton<Locale>));
+    await tester.tap(find.byType(DropdownButton<Locale?>));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Español').last);
     await tester.pumpAndSettle();
 
-    expect(service.locale.languageCode, 'es');
+    expect(service.locale?.languageCode, 'es');
   });
 }

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -53,4 +53,16 @@ void main() {
     await service.setThemeMode(ThemeMode.light);
     expect(notified, isTrue);
   });
+
+  test('setLocale persists value', () async {
+    final service = SettingsService();
+    await service.init();
+
+    await service.setLocale(const Locale('es'));
+    expect(service.locale, const Locale('es'));
+
+    final reloaded = SettingsService();
+    await reloaded.init();
+    expect(reloaded.locale, const Locale('es'));
+  });
 }


### PR DESCRIPTION
## Summary
- persist optional locale in SettingsService using Hive
- drive MaterialApp locale from saved setting with system fallback
- allow choosing system or specific languages in SettingsPage
- add tests for locale persistence and MaterialApp updates

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e72a30d0832b8a4fd86bc8eb9e3a