### PR TITLE
chore: update Spanish app title

### DIFF
--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "es",
-  "appTitle": "Bóveda de la Moda",
+  "appTitle": "Vogue Vault",
   "appointmentsTitle": "Citas",
   "calendarTitle": "Calendario",
   "homeTooltip": "Inicio",

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9,7 +9,7 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
-  String get appTitle => 'Bóveda de la Moda';
+  String get appTitle => 'Vogue Vault';
 
   @override
   String get appointmentsTitle => 'Citas';


### PR DESCRIPTION
## Summary
- replace Spanish appTitle with brand name 'Vogue Vault'
- regenerate localization files

## Testing
- `flutter gen-l10n`
- `flutter test` *(fails: Null argument type can't be assigned to non-null parameter in appointment_service_test.dart and notification_service_test.dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b626deb3cc832b8b69ac73b7ba718a