### PR TITLE
Ignore Android keystore configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ windows/runner/resources/app_icon.ico
 
 # Local draft images
 draftlogin.png
+
+# Android release keystore
+android/key.properties
+android/app/voguevault.jks


### PR DESCRIPTION
## Summary
- ignore Android key.properties and keystore files

## Testing
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b652c132dc832ba586d151733ea0c9