### PR TITLE
Remove auth deletion when removing user

### DIFF
--- a/lib/screens/edit_user_page.dart
+++ b/lib/screens/edit_user_page.dart
@@ -87,7 +87,6 @@ class EditUserPage extends StatelessWidget {
                 if (confirm != true) return;
 
                 try {
-                  await auth.deleteUser(user.id);
                   await service.deleteUser(user.id);
                 } catch (e) {
                   if (!context.mounted) return;


### PR DESCRIPTION
## Summary
- Remove auth.deleteUser call when deleting users in EditUserPage and rely on AppointmentService.deleteUser.

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7266a061c832b8e7fc2edd5695be9