### PR TITLE
Use locale from settings in MaterialApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,10 +34,7 @@ InputDecorationTheme _buildInputDecorationTheme(ColorScheme scheme) {
 }
 
 const TextTheme _textTheme = TextTheme(
-  headlineLarge: TextStyle(
-    fontSize: 32,
-    fontWeight: FontWeight.bold,
-  ),
+  headlineLarge: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
   headlineMedium: TextStyle(
     fontFamily: 'LibertinusSans',
     fontSize: 32,
@@ -53,8 +50,9 @@ Future<void> main() async {
 
   final notificationService = NotificationService();
   await notificationService.init();
-  final appointmentService =
-      AppointmentService(notificationService: notificationService);
+  final appointmentService = AppointmentService(
+    notificationService: notificationService,
+  );
   await appointmentService.init();
   final authService = AuthService();
   await authService.init();
@@ -69,12 +67,8 @@ Future<void> main() async {
           ChangeNotifierProvider<AppointmentService>.value(
             value: appointmentService,
           ),
-          ChangeNotifierProvider<AuthService>.value(
-            value: authService,
-          ),
-          Provider<NotificationService>.value(
-            value: notificationService,
-          ),
+          ChangeNotifierProvider<AuthService>.value(value: authService),
+          Provider<NotificationService>.value(value: notificationService),
         ],
         child: const MyApp(),
       ),
@@ -88,9 +82,8 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final settingsService = context.watch<SettingsService>();
-    final lightScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.primary,
-    ).copyWith(
+    final lightScheme =
+        ColorScheme.fromSeed(seedColor: AppColors.primary).copyWith(
       primary: AppColors.primary,
       surface: AppColors.background,
       secondary: AppColors.secondary,
@@ -133,7 +126,7 @@ class MyApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-      locale: settingsService.locale ?? null,
+      locale: settingsService.locale,
       // Start the app with authentication.
       home: const AuthPage(),
       themeMode: settingsService.themeMode,

--- a/test/main_locale_test.dart
+++ b/test/main_locale_test.dart
@@ -11,10 +11,12 @@ import 'package:vogue_vault/services/settings_service.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   @override
-  Future<String?> getApplicationDocumentsPath() async => Directory.systemTemp.path;
+  Future<String?> getApplicationDocumentsPath() async =>
+      Directory.systemTemp.path;
 
   @override
-  Future<String?> getApplicationSupportPath() async => Directory.systemTemp.path;
+  Future<String?> getApplicationSupportPath() async =>
+      Directory.systemTemp.path;
 
   @override
   Future<String?> getTemporaryPath() async => Directory.systemTemp.path;
@@ -48,17 +50,14 @@ void main() {
                 GlobalCupertinoLocalizations.delegate,
               ],
               supportedLocales: const [Locale('en'), Locale('es')],
-              locale: settings.locale ?? null,
+              locale: settings.locale,
             );
           },
         ),
       ),
     );
 
-    expect(
-      tester.widget<MaterialApp>(find.byType(MaterialApp)).locale,
-      isNull,
-    );
+    expect(tester.widget<MaterialApp>(find.byType(MaterialApp)).locale, isNull);
 
     await service.setLocale(const Locale('es'));
     await tester.pump();


### PR DESCRIPTION
## Summary
- Remove null fallback when passing locale to `MaterialApp`
- Update locale test to match new locale handling

## Testing
- `flutter test` *(fails: argument type 'Null' can't be assigned to the parameter type)*

------
https://chatgpt.com/codex/tasks/task_e_68b7271f7964832baf159004570b4b16