### PR TITLE
Use localized floating labels on auth form

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -102,7 +102,7 @@ class _AuthPageState extends State<AuthPage> {
                   TextFormField(
                     controller: _emailController,
                     decoration: InputDecoration(
-                      hintText: AppLocalizations.of(context)!.emailLabel,
+                      labelText: AppLocalizations.of(context)!.emailLabel,
                       prefixIcon: const Icon(Icons.email),
                     ),
                     validator: (value) {
@@ -121,7 +121,7 @@ class _AuthPageState extends State<AuthPage> {
                     controller: _passwordController,
                     obscureText: !_showPassword,
                     decoration: InputDecoration(
-                      hintText: AppLocalizations.of(context)!.passwordLabel,
+                      labelText: AppLocalizations.of(context)!.passwordLabel,
                       prefixIcon: const Icon(Icons.lock),
                       suffixIcon: IconButton(
                         icon: Icon(


### PR DESCRIPTION
## Summary
- switch the auth form email and password fields to use localized labels instead of hints so floating labels appear while editing
- verified the existing InputDecorationTheme keeps floating label contrast with the onSurface color in both light and dark schemes

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3ea9ef94832b8d88aee37c3c83c9