### PR TITLE
Adjust login header layout

### DIFF
--- a/lib/screens/auth_page.dart
+++ b/lib/screens/auth_page.dart
@@ -84,18 +84,29 @@ class _AuthPageState extends State<AuthPage> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Text(
-                    AppLocalizations.of(context)!.appTitle,
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.headlineMedium,
-                  ),
-                  const SizedBox(height: 16),
-                  Semantics(
-                    label: AppLocalizations.of(context)!.appTitle,
-                    child: Image.asset(
-                      'assets/images/VV_LOGO.webp',
-                      height: 200,
-                      color: colors.onSurface,
+                  Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Semantics(
+                          header: true,
+                          child: Text(
+                            AppLocalizations.of(context)!.appTitle,
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.headlineMedium,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Semantics(
+                          label: AppLocalizations.of(context)!.appTitle,
+                          image: true,
+                          child: Image.asset(
+                            'assets/images/VV_LOGO.webp',
+                            height: 200,
+                            color: colors.onSurface,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                   const SizedBox(height: 32),


### PR DESCRIPTION
## Summary
- center the login header content and mark the title as a semantic header
- ensure the title text renders above the Vogue Vault logo on the auth page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0f0c990c832b937eeeb9517bf5fb