### PR TITLE
Adjust theme contrast colors and add surface/text tokens

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -38,6 +38,11 @@ class AppTheme {
     return ColorScheme.fromSeed(seedColor: AppColors.primary).copyWith(
       primary: AppColors.primary,
       surface: AppColors.background,
+      background: AppColors.background,
+      onSurface: AppColors.textDark,
+      onBackground: AppColors.textDark,
+      surfaceVariant: AppColors.surfaceVariant,
+      onSurfaceVariant: AppColors.textDark.withOpacity(0.8),
       secondary: AppColors.secondary,
       tertiary: AppColors.tertiary,
     );
@@ -52,6 +57,11 @@ class AppTheme {
       secondary: AppColors.secondary,
       tertiary: AppColors.tertiary,
       surface: AppColors.darkBackground,
+      background: AppColors.darkBackground,
+      onSurface: AppColors.textLight,
+      onBackground: AppColors.textLight,
+      surfaceVariant: AppColors.darkSurfaceVariant,
+      onSurfaceVariant: AppColors.textLight.withOpacity(0.8),
     );
   }
 

--- a/lib/utils/color_palette.dart
+++ b/lib/utils/color_palette.dart
@@ -14,8 +14,20 @@ class AppColors {
   /// Light background color ensuring high text contrast.
   static const Color background = Color(0xFFFEFAE0);
 
+  /// Light surface variant used for inputs and cards.
+  static const Color surfaceVariant = Color(0xFFF3E9D2);
+
+  /// High-contrast text color for light surfaces.
+  static const Color textDark = Color(0xFF2E2A24);
+
   /// Dark background color for dark theme surfaces.
   static const Color darkBackground = Color(0xFF121212);
+
+  /// Dark surface variant for elevated elements.
+  static const Color darkSurfaceVariant = Color(0xFF2A2622);
+
+  /// High-contrast text color for dark surfaces.
+  static const Color textLight = Color(0xFFF5F3EF);
 
   /// Additional highlight color for differentiating services.
   static const Color highlight = Color(0xFFE9EDC9);


### PR DESCRIPTION
### Motivation
- Improve text visibility and overall contrast after reports that some UI text (e.g. the password strength label) was not clearly visible. 
- Provide explicit surface and text contrast tokens so light and dark themes can present consistent high-contrast text on surfaces and backgrounds.

### Description
- Added new color tokens to the centralized palette in `lib/utils/color_palette.dart`: `surfaceVariant`, `textDark`, `darkSurfaceVariant`, and `textLight` to represent surface variants and high-contrast text colors. 
- Updated the app color schemes in `lib/app/theme.dart` so both `lightScheme()` and `darkScheme()` set `background`, `onSurface`, `onBackground`, `surfaceVariant`, and `onSurfaceVariant` explicitly. 
- Ensured existing `InputDecorationTheme` and other theme consumers use the updated `ColorScheme` values for improved readability.
- Changes touch `lib/utils/color_palette.dart` and `lib/app/theme.dart`.

### Testing
- No automated Flutter tests were run because the `flutter` tool is not available in the current environment, so the changes were validated only via code inspection and local file diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c2ac95b4832b9a65823b925ff1a2)